### PR TITLE
Fix headers problem in Webhook Actions

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,10 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/humio/terraform-provider-humio/humio"
@@ -25,7 +29,21 @@ var (
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: humio.Provider,
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "clearhaus/humio", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
This PR fixes an issues that I mentioned over [here](https://github.com/humio/terraform-provider-humio/issues/19#issuecomment-1294021919). Creating/importing webhook actions errors with the following output: `webhook.0.headers: must be a map`

It appears the issue is related to the type-expectations of the Humio cli library. 
The fix is equivalent to the mapping required for `SlackPostMessageAction`.

I just wanted to say thanks (again) for fixing provider issues/publishing a fork. Hopefully Crowdstrike will pick it up again in due time.