### PR TITLE
Enable builds for macOS and Windows ARM64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,10 +28,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: arm64
-    - goos: windows
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Enables ARM64 builds for Windows and macOS. Mostly to support Apple's M1/M2 CPUs.