### PR TITLE
Fix webhook and slackpostmessage actions as well as all action tests

### DIFF
--- a/examples/action_email.tf
+++ b/examples/action_email.tf
@@ -9,7 +9,7 @@ resource "humio_action" "example_email" {
 }
 
 resource "humio_action" "example_email_body" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_email_body"
   type       = "EmailAction"
 
@@ -20,7 +20,7 @@ resource "humio_action" "example_email_body" {
 }
 
 resource "humio_action" "example_email_subject" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_email_subject"
   type       = "EmailAction"
 
@@ -31,7 +31,7 @@ resource "humio_action" "example_email_subject" {
 }
 
 resource "humio_action" "example_email_body_subject" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_email_body_subject"
   type       = "EmailAction"
 

--- a/examples/action_opsgenie.tf
+++ b/examples/action_opsgenie.tf
@@ -1,5 +1,5 @@
 resource "humio_action" "example_opsgenie" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_opsgenie"
   type       = "OpsGenieAction"
 

--- a/examples/action_pagerduty.tf
+++ b/examples/action_pagerduty.tf
@@ -1,5 +1,5 @@
 resource "humio_action" "example_pagerduty" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_pagerduty"
   type       = "PagerDutyAction"
 

--- a/examples/action_slack.tf
+++ b/examples/action_slack.tf
@@ -1,5 +1,5 @@
 resource "humio_action" "example_slack" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_slack"
   type       = "SlackAction"
 

--- a/examples/action_slackpostmessage.tf
+++ b/examples/action_slackpostmessage.tf
@@ -1,10 +1,10 @@
 resource "humio_action" "example_slackpostmessage" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_slackpostmessage"
   type       = "SlackPostMessageAction"
 
   slackpostmessage {
-    api_key  = "abcdefghij1234567890"
+    api_token  = "abcdefghij1234567890"
     channels = ["#alerts", "#ops"]
     fields = {
       "Events String" = "{events_str}"

--- a/examples/action_victorops.tf
+++ b/examples/action_victorops.tf
@@ -1,5 +1,5 @@
 resource "humio_action" "example_victorops" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_victorops"
   type       = "VictorOpsAction"
 

--- a/examples/action_webhook.tf
+++ b/examples/action_webhook.tf
@@ -1,7 +1,7 @@
 resource "humio_action" "example_webhook" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_webhook"
-  type       = "WebHookAction"
+  type       = "WebhookAction"
 
   webhook {
     method = "POST"

--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -468,9 +468,13 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 				Value:     value.(string),
 			})
 		}
+		channels := []string{}
+		for _, channel := range properties[0]["fields"].(map[string]interface{}) {
+			channels = append(channels, channel.(string));
+		}
 		action.SlackPostMessageAction = humio.SlackPostMessageAction{
 			ApiToken: properties[0]["api_token"].(string),
-			Channels: properties[0]["channels"].([]string),
+			Channels: channels,
 			Fields:   fields,
 			UseProxy: properties[0]["use_proxy"].(bool),
 		}


### PR DESCRIPTION
Fixes the type of `channels` in `slackpostmessage` and the `type` field of the webhook action.

Also changes so all action tests now use the `sandbox` repository. This is a personal repository every user has now. Not many users have a repository called `humio`.

Test the same way as https://github.com/clearhaus/terraform-provider-humio/pull/6.