### PR TITLE
Fix ingest token test

### DIFF
--- a/examples/ingest_token.tf
+++ b/examples/ingest_token.tf
@@ -1,18 +1,24 @@
 resource "humio_ingest_token" "example_ingest_token_without_parser" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_ingest_token_without_parser"
 }
 
 resource "humio_ingest_token" "example_ingest_token_with_accesslog_parser" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "example_ingest_token_with_accesslog_parser"
   parser     = "accesslog"
+
+  depends_on = [
+    humio_ingest_token.example_ingest_token_without_parser
+  ]
 }
 
 output "ingest_token_without_parser" {
-  value = humio_ingest_token.example_ingest_token_without_parser.token
+  value     = humio_ingest_token.example_ingest_token_without_parser.token
+  sensitive = true
 }
 
 output "ingest_token_with_accesslog_parser" {
-  value = humio_ingest_token.example_ingest_token_with_accesslog_parser.token
+  value     = humio_ingest_token.example_ingest_token_with_accesslog_parser.token
+  sensitive = true
 }


### PR DESCRIPTION
Creating multiple ingest tokens immediately after each other will almost always result in

```hcl
humio_ingest_token.example_ingest_token_without_parser: Creating...
humio_ingest_token.example_ingest_token_with_accesslog_parser: Creating...
humio_ingest_token.example_ingest_token_with_accesslog_parser: Creation complete after 0s [id=sandbox+example_ingest_token_with_accesslog_parser]
╷
│ Error: could not get ingest token: could not find an ingest token with name 'example_ingest_token_without_parser' in repo 'sandbox'
│
│   with humio_ingest_token.example_ingest_token_without_parser,
│   on ingest_token.tf line 1, in resource "humio_ingest_token" "example_ingest_token_without_parser":
│    1: resource "humio_ingest_token" "example_ingest_token_without_parser" {
│
╵
```

This is not a bug with the provider, but Humio's API deciding to throw the first ingest token if multiple are created at the same time.

Using the Humio CLI tool, I can also reproduce this easily:

    $ humioctl ingest-tokens add sandbox first &; humioctl ingest-tokens add sandbox last
    [1] 11157
    Added ingest token "first" with parser "-": 9dd02f67-c976-4f8e-9cf1-07cce6d32109
    [1]  + 11157 done       humioctl ingest-tokens add sandbox first
    Added ingest token "last" with parser "-": 7cf05aa4-9355-4519-bb33-919418ee4a32

Then (several seconds later, for good measure):

    $ humioctl ingest-tokens list sandbox
      NAME |                TOKEN                 | ASSIGNED PARSER
    +------+--------------------------------------+-----------------+
      last | 7cf05aa4-9355-4519-bb33-919418ee4a32 | -

The `first` ingest token is never created.

Running `humioctl ingest-tokens add sandbox first; humioctl ingest-tokens add sandbox last` (without `&`) works.

This PR just adds a `depends_on` clause, forcing Terraform to creates the resources sequentially, which solves the problem in my testing.

I've also implemented a solution with channel-based mutex, but it requires both a mutex on token creation and the the subsequent reading of the newly created token. The mutexes also require several seconds of sleep to work reliably. Arguably, it also not in scope for the provider to circumvent bugs in Humio's API.

Recent versions of Terraform also require `sensitive = true` to be defined on output containing values that are considered sensitive by the provider, so this has been added.


Also changes so the tests now use the `sandbox` repository. This is a personal repository every user has now. Not many users have a repository called `humio`.