### PR TITLE
Fix channels for SlackPostMessage action wrong field and type

### DIFF
--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -469,8 +469,8 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 			})
 		}
 		channels := []string{}
-		for _, channel := range properties[0]["fields"].(map[string]interface{}) {
-			channels = append(channels, channel.(string));
+		for _, channel := range properties[0]["channels"].([]interface{}) {
+			channels = append(channels, channel.(string))
 		}
 		action.SlackPostMessageAction = humio.SlackPostMessageAction{
 			ApiToken: properties[0]["api_token"].(string),


### PR DESCRIPTION
When using the `SlackPostMessageAction` action I noticed that the _fields_ are incorrectly used as _channels_.

In this PR:
* Fix the typo so that _channels_ uses the `channels` property.
* Change the type assertion to match the data of the `channels` property.
