### PR TITLE
Migrate to new Humio GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ main
 .terraform.*
 terraform.tfstate
 terraform.tfstate.*
+humio.test

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A (maintained) fork of https://github.com/humio/terraform-provider-humio which w
 
 ## Currently tested with
 
-- [Terraform](https://www.terraform.io/downloads.html) v1.5.7
-- [Go](https://golang.org/doc/install) 1.21 (to build the provider plugin)
+- [Terraform](https://opentofu.org) v1.10.7
+- [Go](https://golang.org/doc/install) 1.25 (to build the provider plugin)
 
 ## Installing the provider
 
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     humio = {
       source  = "clearhaus/humio"
-      version = "0.5.0"
+      version = "1.0.0"
     }
   }
 }

--- a/examples/alert.tf
+++ b/examples/alert.tf
@@ -66,17 +66,19 @@ resource "humio_alert" "example_alert_with_user_owner" {
   query_ownership_type = "User"
 }
 
+resource "humio_repository" "org_ownership_test" {
+  name        = "example_repo_org_ownership_${local.email_prefix}"
+  description = "Repository for organization query ownership"
+}
 
-# Note: Organization query ownership is not allowed for sandbox repositories.
-# This example would work on a non-sandbox repository.
-# resource "humio_alert" "example_alert_with_organization_owner" {
-#   repository = humio_action.example_email_body.repository
-#   name       = "example_alert_with_organization_owner"
-#
-#   throttle_time_millis = 300000
-#   enabled              = true
-#   query                = "count()"
-#   start                = "1d"
-#
-#   query_ownership_type = "Organization"
-# }
+resource "humio_alert" "example_alert_with_organization_owner" {
+  repository = humio_repository.org_ownership_test.name
+  name       = "example_alert_with_organization_owner"
+
+  throttle_time_millis = 300000
+  enabled              = true
+  query                = "count()"
+  start                = "1d"
+
+  query_ownership_type = "Organization"
+}

--- a/examples/alert.tf
+++ b/examples/alert.tf
@@ -67,14 +67,16 @@ resource "humio_alert" "example_alert_with_user_owner" {
 }
 
 
-resource "humio_alert" "example_alert_with_organization_owner" {
-  repository = humio_action.example_email_body.repository
-  name       = "example_alert_with_organization_owner"
-
-  throttle_time_millis = 300000
-  enabled              = true
-  query                = "count()"
-  start                = "1d"
-
-  query_ownership_type = "Organization"
-}
+# Note: Organization query ownership is not allowed for sandbox repositories.
+# This example would work on a non-sandbox repository.
+# resource "humio_alert" "example_alert_with_organization_owner" {
+#   repository = humio_action.example_email_body.repository
+#   name       = "example_alert_with_organization_owner"
+#
+#   throttle_time_millis = 300000
+#   enabled              = true
+#   query                = "count()"
+#   start                = "1d"
+#
+#   query_ownership_type = "Organization"
+# }

--- a/examples/parser.tf
+++ b/examples/parser.tf
@@ -34,7 +34,7 @@ PARSERSCRIPT
 }
 
 resource "humio_parser" "gc_kafka" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "gc-kafka"
   test_data = [
     "[2018-12-05T07:37:48.685+0000][gc            ] GC(111957) Pause Young (G1 Evacuation Pause) 711M->559M(796M) 9.860ms",
@@ -77,7 +77,7 @@ PARSERSCRIPT
 }
 
 resource "humio_parser" "jenkins_build_log" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "jenkins-build-log"
   tag_fields = ["build", "task"]
   test_data = [
@@ -98,7 +98,7 @@ regex("\\[(?<@timestamp>[^\\]]+)\\]\\s+(?<loglevel>\\S+)\\s+(\\[(?<thread>[^]]+)
 PARSERSCRIPT
 }
 resource "humio_parser" "kafka_gc" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "kafka-gc"
   test_data = [
     "[2018-12-05T07:37:48.685+0000][gc            ] GC(111957) Pause Young (G1 Evacuation Pause) 711M->559M(796M) 9.860ms",
@@ -132,7 +132,7 @@ PARSERSCRIPT
 }
 
 resource "humio_parser" "webfront" {
-  repository = "humio"
+  repository = "sandbox"
   name       = "webfront"
   tag_fields = ["@host", "type"]
   test_data = [

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     humio = {
-      source  = "clearhaus/humio"
-      version = "1.0.0"
+      source = "clearhaus/humio"
     }
   }
 }

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     humio = {
       source  = "clearhaus/humio"
-      version = "0.5.0"
+      version = "1.0.0"
     }
   }
 }

--- a/examples/repository.tf
+++ b/examples/repository.tf
@@ -1,9 +1,9 @@
 resource "humio_repository" "example_repo_minimal_fields_set" {
-  name = "example-repo-minimal-${local.email_prefix}"
+  name = "example_repo_minimal_${local.email_prefix}"
 }
 
 resource "humio_repository" "example_repo_all_fields_set" {
-  name        = "example-repo-all-${local.email_prefix}"
+  name        = "example_repo_all_${local.email_prefix}"
   description = "This is an example"
 
   retention {

--- a/examples/repository.tf
+++ b/examples/repository.tf
@@ -1,9 +1,9 @@
 resource "humio_repository" "example_repo_minimal_fields_set" {
-  name = "example_repo_minimal_fields_set"
+  name = "example-repo-minimal-${local.email_prefix}"
 }
 
 resource "humio_repository" "example_repo_all_fields_set" {
-  name        = "example_repo_all_fields_set"
+  name        = "example-repo-all-${local.email_prefix}"
   description = "This is an example"
 
   retention {

--- a/examples/user.tf
+++ b/examples/user.tf
@@ -1,0 +1,34 @@
+# Get information about the current authenticated user
+data "humio_user" "current" {}
+
+# Example: Use the email prefix (before @) in a repository name
+locals {
+  email_prefix = lower(replace(split("@", data.humio_user.current.email)[0], "/[^a-z0-9]/", ""))
+}
+
+# Output user information
+output "current_user_id" {
+  value       = data.humio_user.current.id
+  description = "The ID of the current authenticated user"
+}
+
+output "current_username" {
+  value       = data.humio_user.current.username
+  description = "The username of the current authenticated user"
+}
+
+output "current_user_email" {
+  value       = data.humio_user.current.email
+  description = "The email of the current authenticated user"
+}
+
+output "current_user_full_name" {
+  value       = data.humio_user.current.full_name
+  description = "The full name of the current authenticated user"
+}
+
+output "is_root_user" {
+  value       = data.humio_user.current.is_root
+  description = "Whether the current user is a root user"
+}
+

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/humio/terraform-provider-humio
+module github.com/clearhaus/terraform-provider-humio
 
 go 1.23.0
 

--- a/go.mod
+++ b/go.mod
@@ -9,19 +9,16 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/humio/cli v0.38.1
 	github.com/testcontainers/testcontainers-go v0.9.0
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
-	github.com/cli/shurcooL-graphql v0.0.4 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
@@ -21,8 +19,6 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cli/shurcooL-graphql v0.0.4 h1:6MogPnQJLjKkaXPyGqPRXOI2qCsQdqNfUY1QSJu2GuY=
-github.com/cli/shurcooL-graphql v0.0.4/go.mod h1:3waN4u02FiZivIV+p1y4d0Jo1jc6BViMA73C+sZo2fk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
@@ -138,8 +134,6 @@ github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv2
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/humio/cli v0.38.1 h1:IqNrGflxCVl0ROG8ZnfwpBr1HQRUYBsZHdGAnmjJUq8=
-github.com/humio/cli v0.38.1/go.mod h1:zzNx41MIApbdo8IHdL+plVNskwu3DzV9NDL9OYyq8HQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/humio/data_source_user.go
+++ b/humio/data_source_user.go
@@ -1,0 +1,61 @@
+package humio
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
+)
+
+func dataSourceUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceUserRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"full_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_root": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceUserRead(_ context.Context, d *schema.ResourceData, client interface{}) diag.Diagnostics {
+	user, err := client.(*humio.Client).Users().GetCurrent()
+	if err != nil {
+		return diag.Errorf("could not get current user: %s", err)
+	}
+
+	d.SetId(user.ID)
+	if err := d.Set("username", user.Username); err != nil {
+		return diag.Errorf("error setting username: %s", err)
+	}
+	if err := d.Set("full_name", user.FullName); err != nil {
+		return diag.Errorf("error setting full_name: %s", err)
+	}
+	if err := d.Set("email", user.Email); err != nil {
+		return diag.Errorf("error setting email: %s", err)
+	}
+	if err := d.Set("is_root", user.IsRoot); err != nil {
+		return diag.Errorf("error setting is_root: %s", err)
+	}
+
+	return nil
+}

--- a/humio/data_source_user_test.go
+++ b/humio/data_source_user_test.go
@@ -1,0 +1,25 @@
+package humio
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceUser(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "humio_user" "test" {}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.humio_user.test", "id"),
+					resource.TestCheckResourceAttrSet("data.humio_user.test", "username"),
+				),
+			},
+		},
+	})
+}

--- a/humio/provider.go
+++ b/humio/provider.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 // tfMap is a shorthand alias for convenience; Terraform uses this type a *lot*.

--- a/humio/provider.go
+++ b/humio/provider.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 // tfMap is a shorthand alias for convenience; Terraform uses this type a *lot*.

--- a/humio/provider.go
+++ b/humio/provider.go
@@ -61,9 +61,12 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"humio_alert":        resourceAlert(),
 			"humio_ingest_token": resourceIngestToken(),
-			"humio_action":     resourceAction(),
+			"humio_action":       resourceAction(),
 			"humio_parser":       resourceParser(),
 			"humio_repository":   resourceRepository(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"humio_user": dataSourceUser(),
 		},
 		Schema: map[string]*schema.Schema{
 			"addr": {

--- a/humio/provider_test.go
+++ b/humio/provider_test.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/humio/terraform-provider-humio/humio/acceptance"
+	"github.com/clearhaus/terraform-provider-humio/humio/acceptance"
 )
 
 func TestProviderInternalValidation(t *testing.T) {

--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -99,6 +99,11 @@ func resourceAction() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -133,6 +138,11 @@ func resourceAction() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -157,6 +167,11 @@ func resourceAction() *schema.Resource {
 								"info",
 							}, false)),
 						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -178,6 +193,11 @@ func resourceAction() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateDiagFunc: validateURL,
+						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},
@@ -231,6 +251,11 @@ func resourceAction() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateDiagFunc: validateURL,
+						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},
@@ -438,6 +463,7 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 			Recipients:      recipients,
 			BodyTemplate:    properties[0]["body_template"].(string),
 			SubjectTemplate: properties[0]["subject_template"].(string),
+			UseProxy:        properties[0]["use_proxy"].(bool),
 		}
 	case humio.ActionTypeHumioRepo:
 		properties := getActionPropertiesFromResourceData(d, "humiorepo", "ingest_token")
@@ -449,12 +475,14 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 		action.OpsGenieAction = humio.OpsGenieAction{
 			ApiUrl:   properties[0]["api_url"].(string),
 			GenieKey: properties[0]["genie_key"].(string),
+			UseProxy: properties[0]["use_proxy"].(bool),
 		}
 	case humio.ActionTypePagerDuty:
 		properties := getActionPropertiesFromResourceData(d, "pagerduty", "routing_key")
 		action.PagerDutyAction = humio.PagerDutyAction{
 			RoutingKey: properties[0]["routing_key"].(string),
 			Severity:   properties[0]["severity"].(string),
+			UseProxy:   properties[0]["use_proxy"].(bool),
 		}
 	case humio.ActionTypeSlack:
 		properties := getActionPropertiesFromResourceData(d, "slack", "url")
@@ -466,8 +494,9 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 			})
 		}
 		action.SlackAction = humio.SlackAction{
-			Url:    properties[0]["url"].(string),
-			Fields: fields,
+			Url:      properties[0]["url"].(string),
+			Fields:   fields,
+			UseProxy: properties[0]["use_proxy"].(bool),
 		}
 	case humio.ActionTypeSlackPostMessage:
 		properties := getActionPropertiesFromResourceData(d, "slackpostmessage", "api_token")
@@ -493,6 +522,7 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 		action.VictorOpsAction = humio.VictorOpsAction{
 			MessageType: properties[0]["message_type"].(string),
 			NotifyUrl:   properties[0]["notify_url"].(string),
+			UseProxy:    properties[0]["use_proxy"].(bool),
 		}
 	case humio.ActionTypeWebhook:
 		properties := getActionPropertiesFromResourceData(d, "webhook", "url")
@@ -542,6 +572,7 @@ func emailFromAction(a *humio.Action) []tfMap {
 	s["recipients"] = a.EmailAction.Recipients
 	s["body_template"] = a.EmailAction.BodyTemplate
 	s["subject_template"] = a.EmailAction.SubjectTemplate
+	s["use_proxy"] = a.EmailAction.UseProxy
 	return []tfMap{s}
 }
 
@@ -555,6 +586,7 @@ func opsgenieFromAction(a *humio.Action) []tfMap {
 	s := tfMap{}
 	s["api_url"] = a.OpsGenieAction.ApiUrl
 	s["genie_key"] = a.OpsGenieAction.GenieKey
+	s["use_proxy"] = a.OpsGenieAction.UseProxy
 	return []tfMap{s}
 }
 
@@ -562,6 +594,7 @@ func pagerdutyFromAction(a *humio.Action) []tfMap {
 	s := tfMap{}
 	s["routing_key"] = a.PagerDutyAction.RoutingKey
 	s["severity"] = a.PagerDutyAction.Severity
+	s["use_proxy"] = a.PagerDutyAction.UseProxy
 	return []tfMap{s}
 }
 
@@ -573,6 +606,7 @@ func slackFromAction(a *humio.Action) []tfMap {
 	}
 	s["fields"] = fields
 	s["url"] = a.SlackAction.Url
+	s["use_proxy"] = a.SlackAction.UseProxy
 	return []tfMap{s}
 }
 
@@ -593,6 +627,7 @@ func victoropsFromAction(a *humio.Action) []tfMap {
 	s := tfMap{}
 	s["message_type"] = a.VictorOpsAction.MessageType
 	s["notify_url"] = a.VictorOpsAction.NotifyUrl
+	s["use_proxy"] = a.VictorOpsAction.UseProxy
 	return []tfMap{s}
 }
 

--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")

--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")

--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -269,6 +269,16 @@ func resourceAction() *schema.Resource {
 							Required:         true,
 							ValidateDiagFunc: validateURL,
 						},
+						"ignore_ssl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"use_proxy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -498,6 +508,8 @@ func actionFromResourceData(d *schema.ResourceData) (humio.Action, error) {
 			Headers:      headers,
 			Method:       properties[0]["method"].(string),
 			Url:          properties[0]["url"].(string),
+			IgnoreSSL:    properties[0]["ignore_ssl"].(bool),
+			UseProxy:     properties[0]["use_proxy"].(bool),
 		}
 	default:
 		return humio.Action{}, fmt.Errorf("unsupported action type: %s", d.Get("type"))
@@ -594,5 +606,7 @@ func webhookFromAction(a *humio.Action) []tfMap {
 	s["headers"] = headers
 	s["method"] = a.WebhookAction.Method
 	s["url"] = a.WebhookAction.Url
+	s["ignore_ssl"] = a.WebhookAction.IgnoreSSL
+	s["use_proxy"] = a.WebhookAction.UseProxy
 	return []tfMap{s}
 }

--- a/humio/resource_action_test.go
+++ b/humio/resource_action_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -1190,9 +1190,9 @@ resource "humio_action" "test" {
 `
 
 var wantEmailAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "EmailAction",
-	Name:   "test-action",
+	Name: "test-action",
 	EmailAction: humio.EmailAction{
 		Recipients:      []string{"test@example.org", "ops@example.org"},
 		BodyTemplate:    "this is the subject",
@@ -1201,18 +1201,18 @@ var wantEmailAction = humio.Action{
 }
 
 var wantHumioRepoAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "HumioRepoAction",
-	Name:   "test-action",
+	Name: "test-action",
 	HumioRepoAction: humio.HumioRepoAction{
 		IngestToken: "12345678901234567890123456789012",
 	},
 }
 
 var wantOpsGenieAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "OpsGenieAction",
-	Name:   "test-action",
+	Name: "test-action",
 	OpsGenieAction: humio.OpsGenieAction{
 		ApiUrl:   "https://example.org",
 		GenieKey: "12345678901234567890123456789012",
@@ -1220,9 +1220,9 @@ var wantOpsGenieAction = humio.Action{
 }
 
 var wantPagerDutyAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "PagerDutyAction",
-	Name:   "test-action",
+	Name: "test-action",
 	PagerDutyAction: humio.PagerDutyAction{
 		RoutingKey: "12345678901234567890123456789012",
 		Severity:   "critical",
@@ -1230,37 +1230,37 @@ var wantPagerDutyAction = humio.Action{
 }
 
 var wantSlackAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "SlackAction",
-	Name:   "test-action",
+	Name: "test-action",
 	SlackAction: humio.SlackAction{
 		Url: "https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ",
 		Fields: []humio.SlackFieldEntryInput{
-			{"Link", "{url}" },
-			{"Query", "{query_string}" },
+			{"Link", "{url}"},
+			{"Query", "{query_string}"},
 		},
 	},
 }
 
 var wantSlackPostMessageAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "SlackPostMessageAction",
-	Name:   "test-action",
+	Name: "test-action",
 	SlackPostMessageAction: humio.SlackPostMessageAction{
 		ApiToken: "12345678901234567890123456789012",
 		Channels: []string{"#alerts", "ops"},
 		Fields: []humio.SlackFieldEntryInput{
-			{"Link", "{url}" },
-			{"Query", "{query_string}" },
+			{"Link", "{url}"},
+			{"Query", "{query_string}"},
 		},
 		UseProxy: true,
 	},
 }
 
 var wantVictorOpsAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "VictorOpsAction",
-	Name:   "test-action",
+	Name: "test-action",
 	VictorOpsAction: humio.VictorOpsAction{
 		MessageType: "12345678901234567890123456789012",
 		NotifyUrl:   "https://example.org",
@@ -1268,9 +1268,9 @@ var wantVictorOpsAction = humio.Action{
 }
 
 var wantWebhookAction = humio.Action{
-	ID:     "",
+	ID:   "",
 	Type: "WebhookAction",
-	Name:   "test-action",
+	Name: "test-action",
 	WebhookAction: humio.WebhookAction{
 		BodyTemplate: "12345678901234567890123456789012",
 		Headers: []humio.HttpHeaderEntryInput{

--- a/humio/resource_action_test.go
+++ b/humio/resource_action_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/humio/resource_action_test.go
+++ b/humio/resource_action_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/humio/resource_alert.go
+++ b/humio/resource_alert.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 func resourceAlert() *schema.Resource {

--- a/humio/resource_alert.go
+++ b/humio/resource_alert.go
@@ -101,7 +101,7 @@ func resourceAlert() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
 					value := v.(string)
-					if value == "Organization" || value == "User" || value == "" {
+					if value == "Organization" || value == "User" {
 						return nil
 					}
 					return diag.Errorf("query_ownership_type must be 'User' or 'Organization' (case sensitive)")

--- a/humio/resource_alert.go
+++ b/humio/resource_alert.go
@@ -91,15 +91,17 @@ func resourceAlert() *schema.Resource {
 			"run_as_user_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"query_ownership_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
 					value := v.(string)
-					if value == "Organization" || value == "User" {
+					if value == "Organization" || value == "User" || value == "" {
 						return nil
 					}
 					return diag.Errorf("query_ownership_type must be 'User' or 'Organization' (case sensitive)")

--- a/humio/resource_alert.go
+++ b/humio/resource_alert.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 func resourceAlert() *schema.Resource {

--- a/humio/resource_alert_test.go
+++ b/humio/resource_alert_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_alert_test.go
+++ b/humio/resource_alert_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_alert_test.go
+++ b/humio/resource_alert_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_ingest_token.go
+++ b/humio/resource_ingest_token.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 func resourceIngestToken() *schema.Resource {

--- a/humio/resource_ingest_token.go
+++ b/humio/resource_ingest_token.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 func resourceIngestToken() *schema.Resource {

--- a/humio/resource_ingest_token_test.go
+++ b/humio/resource_ingest_token_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_ingest_token_test.go
+++ b/humio/resource_ingest_token_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_ingest_token_test.go
+++ b/humio/resource_ingest_token_test.go
@@ -19,9 +19,9 @@ import (
 	"regexp"
 	"testing"
 
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_parser.go
+++ b/humio/resource_parser.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 func resourceParser() *schema.Resource {

--- a/humio/resource_parser.go
+++ b/humio/resource_parser.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 func resourceParser() *schema.Resource {

--- a/humio/resource_parser.go
+++ b/humio/resource_parser.go
@@ -140,10 +140,19 @@ func resourceParserUpdate(ctx context.Context, d *schema.ResourceData, client in
 		return diag.Errorf("could not obtain parser from resource data: %s", err)
 	}
 
-	_, err = client.(*humio.Client).Parsers().Add(
+	// Get existing parser to obtain its ID
+	existingParser, err := client.(*humio.Client).Parsers().Get(
+		d.Get("repository").(string),
+		d.Get("name").(string),
+	)
+	if err != nil {
+		return diag.Errorf("could not get existing parser for update: %s", err)
+	}
+	parser.ID = existingParser.ID
+
+	_, err = client.(*humio.Client).Parsers().Update(
 		d.Get("repository").(string),
 		&parser,
-		true,
 	)
 	if err != nil {
 		return diag.Errorf("could not update parser: %s", err)

--- a/humio/resource_parser_test.go
+++ b/humio/resource_parser_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_parser_test.go
+++ b/humio/resource_parser_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_parser_test.go
+++ b/humio/resource_parser_test.go
@@ -20,9 +20,9 @@ import (
 	"regexp"
 	"testing"
 
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/humio/resource_repository.go
+++ b/humio/resource_repository.go
@@ -31,11 +31,6 @@ func resourceRepository() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
-			"allow_data_deletion": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			"retention": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/humio/resource_repository.go
+++ b/humio/resource_repository.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 )
 
 func resourceRepository() *schema.Resource {

--- a/humio/resource_repository.go
+++ b/humio/resource_repository.go
@@ -164,8 +164,8 @@ func repositoryFromResourceData(d *schema.ResourceData) (humio.Repository, error
 	}
 
 	return humio.Repository{
-		Name:                   d.Get("name").(string),
-		Description:            d.Get("description").(string),
-		RetentionDays:          retentionDays,
+		Name:          d.Get("name").(string),
+		Description:   d.Get("description").(string),
+		RetentionDays: retentionDays,
 	}, nil
 }

--- a/humio/resource_repository.go
+++ b/humio/resource_repository.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 )
 
 func resourceRepository() *schema.Resource {

--- a/humio/resource_repository_test.go
+++ b/humio/resource_repository_test.go
@@ -19,8 +19,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/humio/resource_repository_test.go
+++ b/humio/resource_repository_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	humio "github.com/humio/cli/api"
+	humio "github.com/humio/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -215,11 +215,9 @@ resource "humio_repository" "test" {
 `
 
 var wantRepository = humio.Repository{
-	Name:                   "test-repository",
-	Description:            "important",
-	RetentionDays:          30,
-	IngestRetentionSizeGB:  10,
-	StorageRetentionSizeGB: 5,
+	Name:          "test-repository",
+	Description:   "important",
+	RetentionDays: 30,
 }
 
 func TestEncodeDecodeRepositoryResource(t *testing.T) {

--- a/humio/resource_repository_test.go
+++ b/humio/resource_repository_test.go
@@ -48,7 +48,6 @@ func TestAccRepositoryInvalidInputs(t *testing.T) {
 	accTestCase(t, []resource.TestStep{
 		{Config: config, ExpectError: regexp.MustCompile(`Inappropriate value for attribute "name"`)},
 		{Config: config, ExpectError: regexp.MustCompile(`Inappropriate value for attribute "description"`)},
-		{Config: config, ExpectError: regexp.MustCompile(`Inappropriate value for attribute "allow_data_deletion"`)},
 		//{Config: config, ExpectError: regexp.MustCompile(`Inappropriate value for attribute "retention"`)},
 	}, nil)
 }
@@ -70,7 +69,6 @@ func TestAccRepositoryBasic(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("humio_repository.test", "name", "repository-test"),
 				resource.TestCheckResourceAttr("humio_repository.test", "description", ""),
-				resource.TestCheckResourceAttr("humio_repository.test", "allow_data_deletion", "false"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.#", "1"), // TODO: Figure out if we want to require this set by the user. If not, how can we ensure this is not put in state?
 				resource.TestCheckNoResourceAttr("humio_repository.test", "retention.0.time_in_days"),
 				resource.TestCheckNoResourceAttr("humio_repository.test", "retention.0.ingest_size_in_gb"),
@@ -90,7 +88,6 @@ func TestAccRepositoryBasicToFull(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("humio_repository.test", "name", "repository-test"),
 				resource.TestCheckResourceAttr("humio_repository.test", "description", ""),
-				resource.TestCheckResourceAttr("humio_repository.test", "allow_data_deletion", "false"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.#", "1"), // TODO: Figure out if we want to require this set by the user. If not, how can we ensure this is not put in state?
 				resource.TestCheckNoResourceAttr("humio_repository.test", "retention.0.time_in_days"),
 				resource.TestCheckNoResourceAttr("humio_repository.test", "retention.0.ingest_size_in_gb"),
@@ -105,7 +102,6 @@ func TestAccRepositoryBasicToFull(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("humio_repository.test", "name", "repository-test"),
 				resource.TestCheckResourceAttr("humio_repository.test", "description", "some description"),
-				resource.TestCheckResourceAttr("humio_repository.test", "allow_data_deletion", "true"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.#", "1"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.time_in_days", "30"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.ingest_size_in_gb", "10"),
@@ -122,7 +118,6 @@ func TestAccRepositoryBasicToFull(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("humio_repository.test", "name", "repository-test"),
 				resource.TestCheckResourceAttr("humio_repository.test", "description", "some description"),
-				resource.TestCheckResourceAttr("humio_repository.test", "allow_data_deletion", "true"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.#", "1"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.time_in_days", "30"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.ingest_size_in_gb", "10"),
@@ -142,7 +137,6 @@ func TestAccRepositoryFull(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("humio_repository.test", "name", "repository-test"),
 				resource.TestCheckResourceAttr("humio_repository.test", "description", "some description"),
-				resource.TestCheckResourceAttr("humio_repository.test", "allow_data_deletion", "true"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.#", "1"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.time_in_days", "30"),
 				resource.TestCheckResourceAttr("humio_repository.test", "retention.0.ingest_size_in_gb", "10"),
@@ -178,7 +172,6 @@ const repositoryInvalidInputs = `
 resource "humio_repository" "test" {
     name                = ["invalid"]
     description         = ["invalid"]
-    allow_data_deletion = ["invalid"]
     retention           = "invalid"
 }
 `
@@ -203,9 +196,8 @@ resource "humio_repository" "test" {
 
 const repositoryFull = `
 resource "humio_repository" "test" {
-    name                = "repository-test"
-    description         = "some description"
-    allow_data_deletion = true
+    name        = "repository-test"
+    description = "some description"
     retention {
         storage_size_in_gb = 5
         ingest_size_in_gb  = 10

--- a/humio/resource_repository_test.go
+++ b/humio/resource_repository_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	humio "github.com/humio/terraform-provider-humio/internal/api"
+	humio "github.com/clearhaus/terraform-provider-humio/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -1,0 +1,636 @@
+// Copyright © 2024 Clearhaus
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+// Action type constants
+const (
+	ActionTypeEmail            = "EmailAction"
+	ActionTypeHumioRepo        = "HumioRepoAction"
+	ActionTypeOpsGenie         = "OpsGenieAction"
+	ActionTypePagerDuty        = "PagerDutyAction"
+	ActionTypeSlack            = "SlackAction"
+	ActionTypeSlackPostMessage = "SlackPostMessageAction"
+	ActionTypeVictorOps        = "VictorOpsAction"
+	ActionTypeWebhook          = "WebhookAction"
+)
+
+// Action represents a Humio action
+type Action struct {
+	Type                   string
+	ID                     string
+	Name                   string
+	EmailAction            EmailAction
+	HumioRepoAction        HumioRepoAction
+	OpsGenieAction         OpsGenieAction
+	PagerDutyAction        PagerDutyAction
+	SlackAction            SlackAction
+	SlackPostMessageAction SlackPostMessageAction
+	VictorOpsAction        VictorOpsAction
+	WebhookAction          WebhookAction
+}
+
+// EmailAction represents an email action
+type EmailAction struct {
+	Recipients      []string
+	SubjectTemplate string
+	BodyTemplate    string
+}
+
+// HumioRepoAction represents a Humio repo action
+type HumioRepoAction struct {
+	IngestToken string
+}
+
+// OpsGenieAction represents an OpsGenie action
+type OpsGenieAction struct {
+	ApiUrl   string
+	GenieKey string
+}
+
+// PagerDutyAction represents a PagerDuty action
+type PagerDutyAction struct {
+	RoutingKey string
+	Severity   string
+}
+
+// SlackFieldEntryInput represents a Slack field entry
+type SlackFieldEntryInput struct {
+	FieldName string
+	Value     string
+}
+
+// SlackAction represents a Slack webhook action
+type SlackAction struct {
+	Url    string
+	Fields []SlackFieldEntryInput
+}
+
+// SlackPostMessageAction represents a Slack post message action
+type SlackPostMessageAction struct {
+	ApiToken string
+	Channels []string
+	Fields   []SlackFieldEntryInput
+	UseProxy bool
+}
+
+// VictorOpsAction represents a VictorOps action
+type VictorOpsAction struct {
+	MessageType string
+	NotifyUrl   string
+}
+
+// HttpHeaderEntryInput represents an HTTP header entry
+type HttpHeaderEntryInput struct {
+	Header string
+	Value  string
+}
+
+// WebhookAction represents a webhook action
+type WebhookAction struct {
+	Method       string
+	Url          string
+	Headers      []HttpHeaderEntryInput
+	BodyTemplate string
+}
+
+// Actions provides operations for managing actions
+type Actions struct {
+	client *Client
+}
+
+const listActionsQuery = `
+query ListActions($SearchDomainName: String!) {
+  searchDomain(name: $SearchDomainName) {
+    actions {
+      __typename
+      id
+      name
+      ... on EmailAction {
+        recipients
+        subjectTemplate
+        bodyTemplate
+      }
+      ... on HumioRepoAction {
+        ingestToken
+      }
+      ... on OpsGenieAction {
+        apiUrl
+        genieKey
+      }
+      ... on PagerDutyAction {
+        routingKey
+        severity
+      }
+      ... on SlackAction {
+        url
+        fields {
+          fieldName
+          value
+        }
+      }
+      ... on SlackPostMessageAction {
+        apiToken
+        channels
+        fields {
+          fieldName
+          value
+        }
+        useProxy
+      }
+      ... on VictorOpsAction {
+        messageType
+        notifyUrl
+      }
+      ... on WebhookAction {
+        method
+        url
+        headers {
+          header
+          value
+        }
+        bodyTemplate
+      }
+    }
+  }
+}
+`
+
+const deleteActionMutation = `
+mutation DeleteAction($SearchDomainName: String!, $ActionID: String!) {
+  deleteAction(input: {
+    viewName: $SearchDomainName
+    id: $ActionID
+  })
+}
+`
+
+const createEmailActionMutation = `
+mutation CreateEmailAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $Recipients: [String!]!
+  $SubjectTemplate: String
+  $BodyTemplate: String
+) {
+  createEmailAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    recipients: $Recipients
+    subjectTemplate: $SubjectTemplate
+    bodyTemplate: $BodyTemplate
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createHumioRepoActionMutation = `
+mutation CreateHumioRepoAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $IngestToken: String!
+) {
+  createHumioRepoAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    ingestToken: $IngestToken
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createOpsGenieActionMutation = `
+mutation CreateOpsGenieAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $ApiUrl: String!
+  $GenieKey: String!
+) {
+  createOpsGenieAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    apiUrl: $ApiUrl
+    genieKey: $GenieKey
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createPagerDutyActionMutation = `
+mutation CreatePagerDutyAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $RoutingKey: String!
+  $Severity: String!
+) {
+  createPagerDutyAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    routingKey: $RoutingKey
+    severity: $Severity
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createSlackActionMutation = `
+mutation CreateSlackAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $Url: String!
+  $Fields: [SlackFieldEntryInput!]!
+) {
+  createSlackAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    url: $Url
+    fields: $Fields
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createSlackPostMessageActionMutation = `
+mutation CreateSlackPostMessageAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $ApiToken: String!
+  $Channels: [String!]!
+  $Fields: [SlackFieldEntryInput!]!
+  $UseProxy: Boolean!
+) {
+  createSlackPostMessageAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    apiToken: $ApiToken
+    channels: $Channels
+    fields: $Fields
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createVictorOpsActionMutation = `
+mutation CreateVictorOpsAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $MessageType: String!
+  $NotifyUrl: String!
+) {
+  createVictorOpsAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    messageType: $MessageType
+    notifyUrl: $NotifyUrl
+  }) {
+    id
+    name
+  }
+}
+`
+
+const createWebhookActionMutation = `
+mutation CreateWebhookAction(
+  $SearchDomainName: String!
+  $Name: String!
+  $Url: String!
+  $Method: String!
+  $Headers: [HttpHeaderEntryInput!]!
+  $BodyTemplate: String!
+) {
+  createWebhookAction(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    url: $Url
+    method: $Method
+    headers: $Headers
+    bodyTemplate: $BodyTemplate
+  }) {
+    id
+    name
+  }
+}
+`
+
+// actionResponse represents the response from list actions query
+type actionResponse struct {
+	SearchDomain struct {
+		Actions []struct {
+			Typename        string `json:"__typename"`
+			ID              string `json:"id"`
+			Name            string `json:"name"`
+			Recipients      []string `json:"recipients,omitempty"`
+			SubjectTemplate string `json:"subjectTemplate,omitempty"`
+			BodyTemplate    string `json:"bodyTemplate,omitempty"`
+			IngestToken     string `json:"ingestToken,omitempty"`
+			ApiUrl          string `json:"apiUrl,omitempty"`
+			GenieKey        string `json:"genieKey,omitempty"`
+			RoutingKey      string `json:"routingKey,omitempty"`
+			Severity        string `json:"severity,omitempty"`
+			Url             string `json:"url,omitempty"`
+			Fields          []struct {
+				FieldName string `json:"fieldName"`
+				Value     string `json:"value"`
+			} `json:"fields,omitempty"`
+			ApiToken    string   `json:"apiToken,omitempty"`
+			Channels    []string `json:"channels,omitempty"`
+			UseProxy    bool     `json:"useProxy,omitempty"`
+			MessageType string   `json:"messageType,omitempty"`
+			NotifyUrl   string   `json:"notifyUrl,omitempty"`
+			Method      string   `json:"method,omitempty"`
+			Headers     []struct {
+				Header string `json:"header"`
+				Value  string `json:"value"`
+			} `json:"headers,omitempty"`
+		} `json:"actions"`
+	} `json:"searchDomain"`
+}
+
+type createActionResponse struct {
+	CreateEmailAction            *struct{ ID, Name string } `json:"createEmailAction,omitempty"`
+	CreateHumioRepoAction        *struct{ ID, Name string } `json:"createHumioRepoAction,omitempty"`
+	CreateOpsGenieAction         *struct{ ID, Name string } `json:"createOpsGenieAction,omitempty"`
+	CreatePagerDutyAction        *struct{ ID, Name string } `json:"createPagerDutyAction,omitempty"`
+	CreateSlackAction            *struct{ ID, Name string } `json:"createSlackAction,omitempty"`
+	CreateSlackPostMessageAction *struct{ ID, Name string } `json:"createSlackPostMessageAction,omitempty"`
+	CreateVictorOpsAction        *struct{ ID, Name string } `json:"createVictorOpsAction,omitempty"`
+	CreateWebhookAction          *struct{ ID, Name string } `json:"createWebhookAction,omitempty"`
+}
+
+// List returns all actions for the given repository
+func (a *Actions) List(repository string) ([]Action, error) {
+	var resp actionResponse
+	err := a.client.Query(context.Background(), listActionsQuery, map[string]interface{}{
+		"SearchDomainName": repository,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	actions := make([]Action, len(resp.SearchDomain.Actions))
+	for i, rawAction := range resp.SearchDomain.Actions {
+		action := Action{
+			Type: rawAction.Typename,
+			ID:   rawAction.ID,
+			Name: rawAction.Name,
+		}
+
+		switch rawAction.Typename {
+		case ActionTypeEmail:
+			action.EmailAction = EmailAction{
+				Recipients:      rawAction.Recipients,
+				SubjectTemplate: rawAction.SubjectTemplate,
+				BodyTemplate:    rawAction.BodyTemplate,
+			}
+		case ActionTypeHumioRepo:
+			action.HumioRepoAction = HumioRepoAction{
+				IngestToken: rawAction.IngestToken,
+			}
+		case ActionTypeOpsGenie:
+			action.OpsGenieAction = OpsGenieAction{
+				ApiUrl:   rawAction.ApiUrl,
+				GenieKey: rawAction.GenieKey,
+			}
+		case ActionTypePagerDuty:
+			action.PagerDutyAction = PagerDutyAction{
+				RoutingKey: rawAction.RoutingKey,
+				Severity:   rawAction.Severity,
+			}
+		case ActionTypeSlack:
+			fields := make([]SlackFieldEntryInput, len(rawAction.Fields))
+			for j, f := range rawAction.Fields {
+				fields[j] = SlackFieldEntryInput{FieldName: f.FieldName, Value: f.Value}
+			}
+			action.SlackAction = SlackAction{
+				Url:    rawAction.Url,
+				Fields: fields,
+			}
+		case ActionTypeSlackPostMessage:
+			fields := make([]SlackFieldEntryInput, len(rawAction.Fields))
+			for j, f := range rawAction.Fields {
+				fields[j] = SlackFieldEntryInput{FieldName: f.FieldName, Value: f.Value}
+			}
+			action.SlackPostMessageAction = SlackPostMessageAction{
+				ApiToken: rawAction.ApiToken,
+				Channels: rawAction.Channels,
+				Fields:   fields,
+				UseProxy: rawAction.UseProxy,
+			}
+		case ActionTypeVictorOps:
+			action.VictorOpsAction = VictorOpsAction{
+				MessageType: rawAction.MessageType,
+				NotifyUrl:   rawAction.NotifyUrl,
+			}
+		case ActionTypeWebhook:
+			headers := make([]HttpHeaderEntryInput, len(rawAction.Headers))
+			for j, h := range rawAction.Headers {
+				headers[j] = HttpHeaderEntryInput{Header: h.Header, Value: h.Value}
+			}
+			action.WebhookAction = WebhookAction{
+				Method:       rawAction.Method,
+				Url:          rawAction.Url,
+				Headers:      headers,
+				BodyTemplate: rawAction.BodyTemplate,
+			}
+		}
+
+		actions[i] = action
+	}
+
+	return actions, nil
+}
+
+// Get returns an action by name
+func (a *Actions) Get(repository, name string) (*Action, error) {
+	actions, err := a.List(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, action := range actions {
+		if action.Name == name {
+			return &action, nil
+		}
+	}
+
+	return nil, fmt.Errorf("action not found: %s", name)
+}
+
+// Add creates a new action
+func (a *Actions) Add(repository string, action *Action) (*Action, error) {
+	var resp createActionResponse
+	var mutation string
+	variables := map[string]interface{}{
+		"SearchDomainName": repository,
+		"Name":             action.Name,
+	}
+
+	switch action.Type {
+	case ActionTypeEmail:
+		mutation = createEmailActionMutation
+		variables["Recipients"] = action.EmailAction.Recipients
+		variables["SubjectTemplate"] = action.EmailAction.SubjectTemplate
+		variables["BodyTemplate"] = action.EmailAction.BodyTemplate
+
+	case ActionTypeHumioRepo:
+		mutation = createHumioRepoActionMutation
+		variables["IngestToken"] = action.HumioRepoAction.IngestToken
+
+	case ActionTypeOpsGenie:
+		mutation = createOpsGenieActionMutation
+		variables["ApiUrl"] = action.OpsGenieAction.ApiUrl
+		variables["GenieKey"] = action.OpsGenieAction.GenieKey
+
+	case ActionTypePagerDuty:
+		mutation = createPagerDutyActionMutation
+		variables["RoutingKey"] = action.PagerDutyAction.RoutingKey
+		variables["Severity"] = action.PagerDutyAction.Severity
+
+	case ActionTypeSlack:
+		mutation = createSlackActionMutation
+		variables["Url"] = action.SlackAction.Url
+		fields := make([]map[string]string, len(action.SlackAction.Fields))
+		for i, f := range action.SlackAction.Fields {
+			fields[i] = map[string]string{"fieldName": f.FieldName, "value": f.Value}
+		}
+		variables["Fields"] = fields
+
+	case ActionTypeSlackPostMessage:
+		mutation = createSlackPostMessageActionMutation
+		variables["ApiToken"] = action.SlackPostMessageAction.ApiToken
+		variables["Channels"] = action.SlackPostMessageAction.Channels
+		fields := make([]map[string]string, len(action.SlackPostMessageAction.Fields))
+		for i, f := range action.SlackPostMessageAction.Fields {
+			fields[i] = map[string]string{"fieldName": f.FieldName, "value": f.Value}
+		}
+		variables["Fields"] = fields
+		variables["UseProxy"] = action.SlackPostMessageAction.UseProxy
+
+	case ActionTypeVictorOps:
+		mutation = createVictorOpsActionMutation
+		variables["MessageType"] = action.VictorOpsAction.MessageType
+		variables["NotifyUrl"] = action.VictorOpsAction.NotifyUrl
+
+	case ActionTypeWebhook:
+		mutation = createWebhookActionMutation
+		variables["Url"] = action.WebhookAction.Url
+		variables["Method"] = action.WebhookAction.Method
+		headers := make([]map[string]string, len(action.WebhookAction.Headers))
+		for i, h := range action.WebhookAction.Headers {
+			headers[i] = map[string]string{"header": h.Header, "value": h.Value}
+		}
+		variables["Headers"] = headers
+		variables["BodyTemplate"] = action.WebhookAction.BodyTemplate
+
+	default:
+		return nil, fmt.Errorf("unsupported action type: %s", action.Type)
+	}
+
+	err := a.client.Query(context.Background(), mutation, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the ID from the response
+	switch action.Type {
+	case ActionTypeEmail:
+		if resp.CreateEmailAction != nil {
+			action.ID = resp.CreateEmailAction.ID
+		}
+	case ActionTypeHumioRepo:
+		if resp.CreateHumioRepoAction != nil {
+			action.ID = resp.CreateHumioRepoAction.ID
+		}
+	case ActionTypeOpsGenie:
+		if resp.CreateOpsGenieAction != nil {
+			action.ID = resp.CreateOpsGenieAction.ID
+		}
+	case ActionTypePagerDuty:
+		if resp.CreatePagerDutyAction != nil {
+			action.ID = resp.CreatePagerDutyAction.ID
+		}
+	case ActionTypeSlack:
+		if resp.CreateSlackAction != nil {
+			action.ID = resp.CreateSlackAction.ID
+		}
+	case ActionTypeSlackPostMessage:
+		if resp.CreateSlackPostMessageAction != nil {
+			action.ID = resp.CreateSlackPostMessageAction.ID
+		}
+	case ActionTypeVictorOps:
+		if resp.CreateVictorOpsAction != nil {
+			action.ID = resp.CreateVictorOpsAction.ID
+		}
+	case ActionTypeWebhook:
+		if resp.CreateWebhookAction != nil {
+			action.ID = resp.CreateWebhookAction.ID
+		}
+	}
+
+	return action, nil
+}
+
+// Update updates an existing action by deleting and recreating it
+func (a *Actions) Update(repository string, action *Action) (*Action, error) {
+	// First get the existing action to get its ID
+	existing, err := a.Get(repository, action.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing action: %w", err)
+	}
+
+	// Delete the existing action
+	if err := a.Delete(repository, existing.ID); err != nil {
+		return nil, fmt.Errorf("failed to delete existing action: %w", err)
+	}
+
+	// Create the new action
+	return a.Add(repository, action)
+}
+
+// Delete deletes an action by name or ID
+func (a *Actions) Delete(repository, actionNameOrID string) error {
+	actionID := actionNameOrID
+
+	// If it doesn't look like an ID, try to find the action by name
+	if len(actionNameOrID) < 20 {
+		action, err := a.Get(repository, actionNameOrID)
+		if err != nil {
+			return err
+		}
+		actionID = action.ID
+	}
+
+	return a.client.Query(context.Background(), deleteActionMutation, map[string]interface{}{
+		"SearchDomainName": repository,
+		"ActionID":         actionID,
+	}, nil)
+}

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -355,6 +355,196 @@ mutation CreateWebhookAction(
 }
 `
 
+const updateEmailActionMutation = `
+mutation UpdateEmailAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $Recipients: [String!]!
+  $SubjectTemplate: String
+  $BodyTemplate: String
+  $UseProxy: Boolean!
+) {
+  updateEmailAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    recipients: $Recipients
+    subjectTemplate: $SubjectTemplate
+    bodyTemplate: $BodyTemplate
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateHumioRepoActionMutation = `
+mutation UpdateHumioRepoAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $IngestToken: String!
+) {
+  updateHumioRepoAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    ingestToken: $IngestToken
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateOpsGenieActionMutation = `
+mutation UpdateOpsGenieAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $ApiUrl: String!
+  $GenieKey: String!
+  $UseProxy: Boolean!
+) {
+  updateOpsGenieAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    apiUrl: $ApiUrl
+    genieKey: $GenieKey
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updatePagerDutyActionMutation = `
+mutation UpdatePagerDutyAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $RoutingKey: String!
+  $Severity: String!
+  $UseProxy: Boolean!
+) {
+  updatePagerDutyAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    routingKey: $RoutingKey
+    severity: $Severity
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateSlackActionMutation = `
+mutation UpdateSlackAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $Url: String!
+  $Fields: [SlackFieldEntryInput!]!
+  $UseProxy: Boolean!
+) {
+  updateSlackAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    url: $Url
+    fields: $Fields
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateSlackPostMessageActionMutation = `
+mutation UpdateSlackPostMessageAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $ApiToken: String!
+  $Channels: [String!]!
+  $Fields: [SlackFieldEntryInput!]!
+  $UseProxy: Boolean!
+) {
+  updateSlackPostMessageAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    apiToken: $ApiToken
+    channels: $Channels
+    fields: $Fields
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateVictorOpsActionMutation = `
+mutation UpdateVictorOpsAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $MessageType: String!
+  $NotifyUrl: String!
+  $UseProxy: Boolean!
+) {
+  updateVictorOpsAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    messageType: $MessageType
+    notifyUrl: $NotifyUrl
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
+const updateWebhookActionMutation = `
+mutation UpdateWebhookAction(
+  $SearchDomainName: String!
+  $ID: String!
+  $Name: String!
+  $Url: String!
+  $Method: String!
+  $Headers: [HttpHeaderEntryInput!]!
+  $BodyTemplate: String!
+  $IgnoreSSL: Boolean!
+  $UseProxy: Boolean!
+) {
+  updateWebhookAction(input: {
+    viewName: $SearchDomainName
+    id: $ID
+    name: $Name
+    url: $Url
+    method: $Method
+    headers: $Headers
+    bodyTemplate: $BodyTemplate
+    ignoreSSL: $IgnoreSSL
+    useProxy: $UseProxy
+  }) {
+    id
+    name
+  }
+}
+`
+
 // actionResponse represents the response from list actions query
 type actionResponse struct {
 	SearchDomain struct {
@@ -407,6 +597,17 @@ type createActionResponse struct {
 	CreateSlackPostMessageAction *struct{ ID, Name string } `json:"createSlackPostMessageAction,omitempty"`
 	CreateVictorOpsAction        *struct{ ID, Name string } `json:"createVictorOpsAction,omitempty"`
 	CreateWebhookAction          *struct{ ID, Name string } `json:"createWebhookAction,omitempty"`
+}
+
+type updateActionResponse struct {
+	UpdateEmailAction            *struct{ ID, Name string } `json:"updateEmailAction,omitempty"`
+	UpdateHumioRepoAction        *struct{ ID, Name string } `json:"updateHumioRepoAction,omitempty"`
+	UpdateOpsGenieAction         *struct{ ID, Name string } `json:"updateOpsGenieAction,omitempty"`
+	UpdatePagerDutyAction        *struct{ ID, Name string } `json:"updatePagerDutyAction,omitempty"`
+	UpdateSlackAction            *struct{ ID, Name string } `json:"updateSlackAction,omitempty"`
+	UpdateSlackPostMessageAction *struct{ ID, Name string } `json:"updateSlackPostMessageAction,omitempty"`
+	UpdateVictorOpsAction        *struct{ ID, Name string } `json:"updateVictorOpsAction,omitempty"`
+	UpdateWebhookAction          *struct{ ID, Name string } `json:"updateWebhookAction,omitempty"`
 }
 
 // List returns all actions for the given repository
@@ -640,33 +841,100 @@ func (a *Actions) Add(repository string, action *Action) (*Action, error) {
 	return action, nil
 }
 
-// Update updates an existing action by deleting and recreating it
+// Update updates an existing action in place
 func (a *Actions) Update(repository string, action *Action) (*Action, error) {
-	// First get the existing action to get its ID
-	existing, err := a.Get(repository, action.Name)
+	var resp updateActionResponse
+	var mutation string
+	variables := map[string]interface{}{
+		"SearchDomainName": repository,
+		"ID":               action.ID,
+		"Name":             action.Name,
+	}
+
+	switch action.Type {
+	case ActionTypeEmail:
+		mutation = updateEmailActionMutation
+		variables["Recipients"] = action.EmailAction.Recipients
+		if action.EmailAction.SubjectTemplate != "" {
+			variables["SubjectTemplate"] = action.EmailAction.SubjectTemplate
+		}
+		if action.EmailAction.BodyTemplate != "" {
+			variables["BodyTemplate"] = action.EmailAction.BodyTemplate
+		}
+		variables["UseProxy"] = action.EmailAction.UseProxy
+
+	case ActionTypeHumioRepo:
+		mutation = updateHumioRepoActionMutation
+		variables["IngestToken"] = action.HumioRepoAction.IngestToken
+
+	case ActionTypeOpsGenie:
+		mutation = updateOpsGenieActionMutation
+		variables["ApiUrl"] = action.OpsGenieAction.ApiUrl
+		variables["GenieKey"] = action.OpsGenieAction.GenieKey
+		variables["UseProxy"] = action.OpsGenieAction.UseProxy
+
+	case ActionTypePagerDuty:
+		mutation = updatePagerDutyActionMutation
+		variables["RoutingKey"] = action.PagerDutyAction.RoutingKey
+		variables["Severity"] = action.PagerDutyAction.Severity
+		variables["UseProxy"] = action.PagerDutyAction.UseProxy
+
+	case ActionTypeSlack:
+		mutation = updateSlackActionMutation
+		variables["Url"] = action.SlackAction.Url
+		fields := make([]map[string]string, len(action.SlackAction.Fields))
+		for i, f := range action.SlackAction.Fields {
+			fields[i] = map[string]string{"fieldName": f.FieldName, "value": f.Value}
+		}
+		variables["Fields"] = fields
+		variables["UseProxy"] = action.SlackAction.UseProxy
+
+	case ActionTypeSlackPostMessage:
+		mutation = updateSlackPostMessageActionMutation
+		variables["ApiToken"] = action.SlackPostMessageAction.ApiToken
+		variables["Channels"] = action.SlackPostMessageAction.Channels
+		fields := make([]map[string]string, len(action.SlackPostMessageAction.Fields))
+		for i, f := range action.SlackPostMessageAction.Fields {
+			fields[i] = map[string]string{"fieldName": f.FieldName, "value": f.Value}
+		}
+		variables["Fields"] = fields
+		variables["UseProxy"] = action.SlackPostMessageAction.UseProxy
+
+	case ActionTypeVictorOps:
+		mutation = updateVictorOpsActionMutation
+		variables["MessageType"] = action.VictorOpsAction.MessageType
+		variables["NotifyUrl"] = action.VictorOpsAction.NotifyUrl
+		variables["UseProxy"] = action.VictorOpsAction.UseProxy
+
+	case ActionTypeWebhook:
+		mutation = updateWebhookActionMutation
+		variables["Url"] = action.WebhookAction.Url
+		variables["Method"] = action.WebhookAction.Method
+		headers := make([]map[string]string, len(action.WebhookAction.Headers))
+		for i, h := range action.WebhookAction.Headers {
+			headers[i] = map[string]string{"header": h.Header, "value": h.Value}
+		}
+		variables["Headers"] = headers
+		variables["BodyTemplate"] = action.WebhookAction.BodyTemplate
+		variables["IgnoreSSL"] = action.WebhookAction.IgnoreSSL
+		variables["UseProxy"] = action.WebhookAction.UseProxy
+
+	default:
+		return nil, fmt.Errorf("unsupported action type: %s", action.Type)
+	}
+
+	err := a.client.Query(context.Background(), mutation, variables, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get existing action: %w", err)
+		return nil, err
 	}
 
-	// Delete the existing action
-	if err := a.Delete(repository, existing.ID); err != nil {
-		return nil, fmt.Errorf("failed to delete existing action: %w", err)
-	}
-
-	// Create the new action
-	return a.Add(repository, action)
+	return action, nil
 }
 
-// Delete deletes an action by name
-func (a *Actions) Delete(repository, actionName string) error {
-	// Look up the action by name to get its ID
-	action, err := a.Get(repository, actionName)
-	if err != nil {
-		return err
-	}
-
+// Delete deletes an action by ID
+func (a *Actions) Delete(repository, actionID string) error {
 	return a.client.Query(context.Background(), deleteActionMutation, map[string]interface{}{
 		"SearchDomainName": repository,
-		"ActionID":         action.ID,
+		"ActionID":         actionID,
 	}, nil)
 }

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -549,38 +549,38 @@ mutation UpdateWebhookAction(
 type actionResponse struct {
 	SearchDomain struct {
 		Actions []struct {
-			Typename              string   `json:"__typename"`
-			ID                    string   `json:"id"`
-			Name                  string   `json:"name"`
-			Recipients            []string `json:"recipients,omitempty"`
-			SubjectTemplate       string   `json:"subjectTemplate,omitempty"`
-			EmailBodyTemplate     string   `json:"emailBodyTemplate,omitempty"`
-			EmailUseProxy         bool     `json:"emailUseProxy,omitempty"`
-			IngestToken           string   `json:"ingestToken,omitempty"`
-			ApiUrl                string   `json:"apiUrl,omitempty"`
-			GenieKey              string   `json:"genieKey,omitempty"`
-			OpsGenieUseProxy      bool     `json:"opsGenieUseProxy,omitempty"`
-			RoutingKey            string   `json:"routingKey,omitempty"`
-			Severity              string   `json:"severity,omitempty"`
-			PagerDutyUseProxy     bool     `json:"pagerDutyUseProxy,omitempty"`
-			Url                   string   `json:"url,omitempty"`
-			SlackUseProxy         bool     `json:"slackUseProxy,omitempty"`
-			Fields                []struct {
+			Typename          string   `json:"__typename"`
+			ID                string   `json:"id"`
+			Name              string   `json:"name"`
+			Recipients        []string `json:"recipients,omitempty"`
+			SubjectTemplate   string   `json:"subjectTemplate,omitempty"`
+			EmailBodyTemplate string   `json:"emailBodyTemplate,omitempty"`
+			EmailUseProxy     bool     `json:"emailUseProxy,omitempty"`
+			IngestToken       string   `json:"ingestToken,omitempty"`
+			ApiUrl            string   `json:"apiUrl,omitempty"`
+			GenieKey          string   `json:"genieKey,omitempty"`
+			OpsGenieUseProxy  bool     `json:"opsGenieUseProxy,omitempty"`
+			RoutingKey        string   `json:"routingKey,omitempty"`
+			Severity          string   `json:"severity,omitempty"`
+			PagerDutyUseProxy bool     `json:"pagerDutyUseProxy,omitempty"`
+			Url               string   `json:"url,omitempty"`
+			SlackUseProxy     bool     `json:"slackUseProxy,omitempty"`
+			Fields            []struct {
 				FieldName string `json:"fieldName"`
 				Value     string `json:"value"`
 			} `json:"fields,omitempty"`
-			ApiToken              string   `json:"apiToken,omitempty"`
-			Channels              []string `json:"channels,omitempty"`
-			UseProxy              bool     `json:"useProxy,omitempty"`
-			MessageType           string   `json:"messageType,omitempty"`
-			NotifyUrl             string   `json:"notifyUrl,omitempty"`
-			VictorOpsUseProxy     bool     `json:"victorOpsUseProxy,omitempty"`
-			Method                string   `json:"method,omitempty"`
-			WebhookUrl            string   `json:"webhookUrl,omitempty"`
-			WebhookBodyTemplate   string   `json:"webhookBodyTemplate,omitempty"`
-			IgnoreSSL             bool     `json:"ignoreSSL,omitempty"`
-			WebhookUseProxy       bool     `json:"webhookUseProxy,omitempty"`
-			Headers               []struct {
+			ApiToken            string   `json:"apiToken,omitempty"`
+			Channels            []string `json:"channels,omitempty"`
+			UseProxy            bool     `json:"useProxy,omitempty"`
+			MessageType         string   `json:"messageType,omitempty"`
+			NotifyUrl           string   `json:"notifyUrl,omitempty"`
+			VictorOpsUseProxy   bool     `json:"victorOpsUseProxy,omitempty"`
+			Method              string   `json:"method,omitempty"`
+			WebhookUrl          string   `json:"webhookUrl,omitempty"`
+			WebhookBodyTemplate string   `json:"webhookBodyTemplate,omitempty"`
+			IgnoreSSL           bool     `json:"ignoreSSL,omitempty"`
+			WebhookUseProxy     bool     `json:"webhookUseProxy,omitempty"`
+			Headers             []struct {
 				Header string `json:"header"`
 				Value  string `json:"value"`
 			} `json:"headers,omitempty"`

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (
@@ -345,18 +331,18 @@ mutation CreateWebhookAction(
 type actionResponse struct {
 	SearchDomain struct {
 		Actions []struct {
-			Typename        string `json:"__typename"`
-			ID              string `json:"id"`
-			Name            string `json:"name"`
+			Typename        string   `json:"__typename"`
+			ID              string   `json:"id"`
+			Name            string   `json:"name"`
 			Recipients      []string `json:"recipients,omitempty"`
-			SubjectTemplate string `json:"subjectTemplate,omitempty"`
-			BodyTemplate    string `json:"bodyTemplate,omitempty"`
-			IngestToken     string `json:"ingestToken,omitempty"`
-			ApiUrl          string `json:"apiUrl,omitempty"`
-			GenieKey        string `json:"genieKey,omitempty"`
-			RoutingKey      string `json:"routingKey,omitempty"`
-			Severity        string `json:"severity,omitempty"`
-			Url             string `json:"url,omitempty"`
+			SubjectTemplate string   `json:"subjectTemplate,omitempty"`
+			BodyTemplate    string   `json:"bodyTemplate,omitempty"`
+			IngestToken     string   `json:"ingestToken,omitempty"`
+			ApiUrl          string   `json:"apiUrl,omitempty"`
+			GenieKey        string   `json:"genieKey,omitempty"`
+			RoutingKey      string   `json:"routingKey,omitempty"`
+			Severity        string   `json:"severity,omitempty"`
+			Url             string   `json:"url,omitempty"`
 			Fields          []struct {
 				FieldName string `json:"fieldName"`
 				Value     string `json:"value"`

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -49,12 +49,14 @@ type HumioRepoAction struct {
 type OpsGenieAction struct {
 	ApiUrl   string
 	GenieKey string
+	UseProxy bool
 }
 
 // PagerDutyAction represents a PagerDuty action
 type PagerDutyAction struct {
 	RoutingKey string
 	Severity   string
+	UseProxy   bool
 }
 
 // SlackFieldEntryInput represents a Slack field entry
@@ -65,8 +67,9 @@ type SlackFieldEntryInput struct {
 
 // SlackAction represents a Slack webhook action
 type SlackAction struct {
-	Url    string
-	Fields []SlackFieldEntryInput
+	Url      string
+	Fields   []SlackFieldEntryInput
+	UseProxy bool
 }
 
 // SlackPostMessageAction represents a Slack post message action
@@ -81,6 +84,7 @@ type SlackPostMessageAction struct {
 type VictorOpsAction struct {
 	MessageType string
 	NotifyUrl   string
+	UseProxy    bool
 }
 
 // HttpHeaderEntryInput represents an HTTP header entry
@@ -219,12 +223,14 @@ mutation CreateOpsGenieAction(
   $Name: String!
   $ApiUrl: String!
   $GenieKey: String!
+  $UseProxy: Boolean!
 ) {
   createOpsGenieAction(input: {
     viewName: $SearchDomainName
     name: $Name
     apiUrl: $ApiUrl
     genieKey: $GenieKey
+    useProxy: $UseProxy
   }) {
     id
     name
@@ -238,12 +244,14 @@ mutation CreatePagerDutyAction(
   $Name: String!
   $RoutingKey: String!
   $Severity: String!
+  $UseProxy: Boolean!
 ) {
   createPagerDutyAction(input: {
     viewName: $SearchDomainName
     name: $Name
     routingKey: $RoutingKey
     severity: $Severity
+    useProxy: $UseProxy
   }) {
     id
     name
@@ -257,12 +265,14 @@ mutation CreateSlackAction(
   $Name: String!
   $Url: String!
   $Fields: [SlackFieldEntryInput!]!
+  $UseProxy: Boolean!
 ) {
   createSlackAction(input: {
     viewName: $SearchDomainName
     name: $Name
     url: $Url
     fields: $Fields
+    useProxy: $UseProxy
   }) {
     id
     name
@@ -299,12 +309,14 @@ mutation CreateVictorOpsAction(
   $Name: String!
   $MessageType: String!
   $NotifyUrl: String!
+  $UseProxy: Boolean!
 ) {
   createVictorOpsAction(input: {
     viewName: $SearchDomainName
     name: $Name
     messageType: $MessageType
     notifyUrl: $NotifyUrl
+    useProxy: $UseProxy
   }) {
     id
     name
@@ -516,11 +528,13 @@ func (a *Actions) Add(repository string, action *Action) (*Action, error) {
 		mutation = createOpsGenieActionMutation
 		variables["ApiUrl"] = action.OpsGenieAction.ApiUrl
 		variables["GenieKey"] = action.OpsGenieAction.GenieKey
+		variables["UseProxy"] = action.OpsGenieAction.UseProxy
 
 	case ActionTypePagerDuty:
 		mutation = createPagerDutyActionMutation
 		variables["RoutingKey"] = action.PagerDutyAction.RoutingKey
 		variables["Severity"] = action.PagerDutyAction.Severity
+		variables["UseProxy"] = action.PagerDutyAction.UseProxy
 
 	case ActionTypeSlack:
 		mutation = createSlackActionMutation
@@ -530,6 +544,7 @@ func (a *Actions) Add(repository string, action *Action) (*Action, error) {
 			fields[i] = map[string]string{"fieldName": f.FieldName, "value": f.Value}
 		}
 		variables["Fields"] = fields
+		variables["UseProxy"] = action.SlackAction.UseProxy
 
 	case ActionTypeSlackPostMessage:
 		mutation = createSlackPostMessageActionMutation
@@ -546,6 +561,7 @@ func (a *Actions) Add(repository string, action *Action) (*Action, error) {
 		mutation = createVictorOpsActionMutation
 		variables["MessageType"] = action.VictorOpsAction.MessageType
 		variables["NotifyUrl"] = action.VictorOpsAction.NotifyUrl
+		variables["UseProxy"] = action.VictorOpsAction.UseProxy
 
 	case ActionTypeWebhook:
 		mutation = createWebhookActionMutation

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -657,21 +657,16 @@ func (a *Actions) Update(repository string, action *Action) (*Action, error) {
 	return a.Add(repository, action)
 }
 
-// Delete deletes an action by name or ID
-func (a *Actions) Delete(repository, actionNameOrID string) error {
-	actionID := actionNameOrID
-
-	// If it doesn't look like an ID, try to find the action by name
-	if len(actionNameOrID) < 20 {
-		action, err := a.Get(repository, actionNameOrID)
-		if err != nil {
-			return err
-		}
-		actionID = action.ID
+// Delete deletes an action by name
+func (a *Actions) Delete(repository, actionName string) error {
+	// Look up the action by name to get its ID
+	action, err := a.Get(repository, actionName)
+	if err != nil {
+		return err
 	}
 
 	return a.client.Query(context.Background(), deleteActionMutation, map[string]interface{}{
 		"SearchDomainName": repository,
-		"ActionID":         actionID,
+		"ActionID":         action.ID,
 	}, nil)
 }

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -1,0 +1,267 @@
+// Copyright © 2024 Clearhaus
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+// Alert represents a Humio alert
+type Alert struct {
+	ID                 string
+	Name               string
+	Description        string
+	QueryString        string
+	QueryStart         string
+	ThrottleField      string
+	ThrottleTimeMillis int
+	Enabled            bool
+	Actions            []string
+	Labels             []string
+	RunAsUserID        string
+	QueryOwnershipType string
+}
+
+// Alerts provides operations for managing alerts
+type Alerts struct {
+	client *Client
+}
+
+const listAlertsQuery = `
+query ListAlerts($SearchDomainName: String!) {
+  searchDomain(name: $SearchDomainName) {
+    alerts {
+      id
+      name
+      description
+      queryString
+      queryStart
+      throttleField
+      throttleTimeMillis
+      enabled
+      actions
+      labels
+      queryOwnership {
+        id
+        ... on QueryOwnershipTypeUser {
+          user {
+            id
+          }
+        }
+        ... on QueryOwnershipTypeOrganization {
+          id
+        }
+      }
+    }
+  }
+}
+`
+
+const createAlertMutation = `
+mutation CreateAlert(
+  $SearchDomainName: String!
+  $Name: String!
+  $Description: String
+  $QueryString: String!
+  $QueryStart: String!
+  $ThrottleTimeMillis: Long!
+  $ThrottleField: String
+  $Enabled: Boolean!
+  $Actions: [String!]!
+  $Labels: [String!]
+  $RunAsUserID: String
+  $QueryOwnershipType: QueryOwnershipType
+) {
+  createAlert(input: {
+    viewName: $SearchDomainName
+    name: $Name
+    description: $Description
+    queryString: $QueryString
+    queryStart: $QueryStart
+    throttleTimeMillis: $ThrottleTimeMillis
+    throttleField: $ThrottleField
+    enabled: $Enabled
+    actions: $Actions
+    labels: $Labels
+    runAsUserId: $RunAsUserID
+    queryOwnershipType: $QueryOwnershipType
+  }) {
+    id
+    name
+  }
+}
+`
+
+const deleteAlertMutation = `
+mutation DeleteAlert($SearchDomainName: String!, $AlertID: String!) {
+  deleteAlert(input: {
+    viewName: $SearchDomainName
+    id: $AlertID
+  })
+}
+`
+
+// alertResponse is the response structure for alert queries
+type alertResponse struct {
+	SearchDomain struct {
+		Alerts []struct {
+			ID                 string   `json:"id"`
+			Name               string   `json:"name"`
+			Description        string   `json:"description"`
+			QueryString        string   `json:"queryString"`
+			QueryStart         string   `json:"queryStart"`
+			ThrottleField      string   `json:"throttleField"`
+			ThrottleTimeMillis int      `json:"throttleTimeMillis"`
+			Enabled            bool     `json:"enabled"`
+			Actions            []string `json:"actions"`
+			Labels             []string `json:"labels"`
+			QueryOwnership     struct {
+				ID   string `json:"id"`
+				User *struct {
+					ID string `json:"id"`
+				} `json:"user,omitempty"`
+			} `json:"queryOwnership"`
+		} `json:"alerts"`
+	} `json:"searchDomain"`
+}
+
+// createAlertResponse is the response structure for creating an alert
+type createAlertResponse struct {
+	CreateAlert struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"createAlert"`
+}
+
+// List returns all alerts for the given repository
+func (a *Alerts) List(repository string) ([]Alert, error) {
+	var resp alertResponse
+	err := a.client.Query(context.Background(), listAlertsQuery, map[string]interface{}{
+		"SearchDomainName": repository,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	alerts := make([]Alert, len(resp.SearchDomain.Alerts))
+	for i, alert := range resp.SearchDomain.Alerts {
+		ownershipType := "Organization"
+		runAsUserID := ""
+		if alert.QueryOwnership.User != nil {
+			ownershipType = "User"
+			runAsUserID = alert.QueryOwnership.User.ID
+		}
+
+		alerts[i] = Alert{
+			ID:                 alert.ID,
+			Name:               alert.Name,
+			Description:        alert.Description,
+			QueryString:        alert.QueryString,
+			QueryStart:         alert.QueryStart,
+			ThrottleField:      alert.ThrottleField,
+			ThrottleTimeMillis: alert.ThrottleTimeMillis,
+			Enabled:            alert.Enabled,
+			Actions:            alert.Actions,
+			Labels:             alert.Labels,
+			RunAsUserID:        runAsUserID,
+			QueryOwnershipType: ownershipType,
+		}
+	}
+
+	return alerts, nil
+}
+
+// Get returns an alert by name
+func (a *Alerts) Get(repository, name string) (*Alert, error) {
+	alerts, err := a.List(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, alert := range alerts {
+		if alert.Name == name {
+			return &alert, nil
+		}
+	}
+
+	return nil, fmt.Errorf("alert not found: %s", name)
+}
+
+// Add creates a new alert
+func (a *Alerts) Add(repository string, alert *Alert) (*Alert, error) {
+	variables := map[string]interface{}{
+		"SearchDomainName":   repository,
+		"Name":               alert.Name,
+		"Description":        alert.Description,
+		"QueryString":        alert.QueryString,
+		"QueryStart":         alert.QueryStart,
+		"ThrottleTimeMillis": alert.ThrottleTimeMillis,
+		"ThrottleField":      alert.ThrottleField,
+		"Enabled":            alert.Enabled,
+		"Actions":            alert.Actions,
+		"Labels":             alert.Labels,
+	}
+
+	if alert.RunAsUserID != "" {
+		variables["RunAsUserID"] = alert.RunAsUserID
+	}
+	if alert.QueryOwnershipType != "" {
+		variables["QueryOwnershipType"] = alert.QueryOwnershipType
+	}
+
+	var resp createAlertResponse
+	err := a.client.Query(context.Background(), createAlertMutation, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	alert.ID = resp.CreateAlert.ID
+	return alert, nil
+}
+
+// Update updates an existing alert by deleting and recreating it
+func (a *Alerts) Update(repository string, alert *Alert) (*Alert, error) {
+	// First get the existing alert to get its ID
+	existing, err := a.Get(repository, alert.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get existing alert: %w", err)
+	}
+
+	// Delete the existing alert
+	if err := a.Delete(repository, existing.ID); err != nil {
+		return nil, fmt.Errorf("failed to delete existing alert: %w", err)
+	}
+
+	// Create the new alert
+	return a.Add(repository, alert)
+}
+
+// Delete deletes an alert by ID
+func (a *Alerts) Delete(repository, alertID string) error {
+	// If alertID looks like a name, get the actual ID first
+	if len(alertID) < 20 { // IDs are typically UUIDs
+		alert, err := a.Get(repository, alertID)
+		if err != nil {
+			return err
+		}
+		alertID = alert.ID
+	}
+
+	return a.client.Query(context.Background(), deleteAlertMutation, map[string]interface{}{
+		"SearchDomainName": repository,
+		"AlertID":          alertID,
+	}, nil)
+}

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -195,12 +195,14 @@ func (a *Alerts) Add(repository string, alert *Alert) (*Alert, error) {
 		"QueryString":        alert.QueryString,
 		"QueryStart":         alert.QueryStart,
 		"ThrottleTimeMillis": alert.ThrottleTimeMillis,
-		"ThrottleField":      alert.ThrottleField,
 		"Enabled":            alert.Enabled,
 		"Actions":            actions,
 		"Labels":             labels,
 	}
 
+	if alert.ThrottleField != "" {
+		variables["ThrottleField"] = alert.ThrottleField
+	}
 	if alert.RunAsUserID != "" {
 		variables["RunAsUserID"] = alert.RunAsUserID
 	}
@@ -235,19 +237,16 @@ func (a *Alerts) Update(repository string, alert *Alert) (*Alert, error) {
 	return a.Add(repository, alert)
 }
 
-// Delete deletes an alert by ID
-func (a *Alerts) Delete(repository, alertID string) error {
-	// If alertID looks like a name, get the actual ID first
-	if len(alertID) < 20 { // IDs are typically UUIDs
-		alert, err := a.Get(repository, alertID)
-		if err != nil {
-			return err
-		}
-		alertID = alert.ID
+// Delete deletes an alert by name
+func (a *Alerts) Delete(repository, alertName string) error {
+	// Look up the alert by name to get its ID
+	alert, err := a.Get(repository, alertName)
+	if err != nil {
+		return err
 	}
 
 	return a.client.Query(context.Background(), deleteAlertMutation, map[string]interface{}{
 		"SearchDomainName": repository,
-		"AlertID":          alertID,
+		"AlertID":          alert.ID,
 	}, nil)
 }

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -222,14 +222,8 @@ func (a *Alerts) Add(repository string, alert *Alert) (*Alert, error) {
 
 // Update updates an existing alert by deleting and recreating it
 func (a *Alerts) Update(repository string, alert *Alert) (*Alert, error) {
-	// First get the existing alert to get its ID
-	existing, err := a.Get(repository, alert.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get existing alert: %w", err)
-	}
-
 	// Delete the existing alert
-	if err := a.Delete(repository, existing.ID); err != nil {
+	if err := a.Delete(repository, alert.Name); err != nil {
 		return nil, fmt.Errorf("failed to delete existing alert: %w", err)
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -161,3 +161,8 @@ func (c *Client) Repositories() *Repositories {
 func (c *Client) IngestTokens() *IngestTokens {
 	return &IngestTokens{client: c}
 }
+
+// Users returns the Users API
+func (c *Client) Users() *Users {
+	return &Users{client: c}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -62,6 +62,8 @@ type graphQLError struct {
 	Message    string                 `json:"message"`
 	Path       []interface{}          `json:"path,omitempty"`
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
+	State      map[string]interface{} `json:"state,omitempty"`
+	ErrorCode  string                 `json:"errorCode,omitempty"`
 }
 
 // Query executes a GraphQL query and unmarshals the result into the provided target
@@ -109,6 +111,15 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]i
 		messages := make([]string, len(gqlResp.Errors))
 		for i, e := range gqlResp.Errors {
 			msg := e.Message
+			// Include validation details from state (e.g., "name": "Name 'foo' is already taken.")
+			if len(e.State) > 0 {
+				for field, detail := range e.State {
+					msg = fmt.Sprintf("%s: %s=%v", msg, field, detail)
+				}
+			}
+			if e.ErrorCode != "" {
+				msg = fmt.Sprintf("%s (errorCode: %s)", msg, e.ErrorCode)
+			}
 			if len(e.Extensions) > 0 {
 				msg = fmt.Sprintf("%s (extensions: %v)", msg, e.Extensions)
 			}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -59,8 +59,9 @@ type graphQLResponse struct {
 
 // graphQLError represents a GraphQL error
 type graphQLError struct {
-	Message string        `json:"message"`
-	Path    []interface{} `json:"path,omitempty"`
+	Message    string                 `json:"message"`
+	Path       []interface{}          `json:"path,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
 // Query executes a GraphQL query and unmarshals the result into the provided target
@@ -107,7 +108,11 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]i
 	if len(gqlResp.Errors) > 0 {
 		messages := make([]string, len(gqlResp.Errors))
 		for i, e := range gqlResp.Errors {
-			messages[i] = e.Message
+			msg := e.Message
+			if len(e.Extensions) > 0 {
+				msg = fmt.Sprintf("%s (extensions: %v)", msg, e.Extensions)
+			}
+			messages[i] = msg
 		}
 		return fmt.Errorf("GraphQL errors: %v", messages)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (
@@ -73,7 +59,7 @@ type graphQLResponse struct {
 
 // graphQLError represents a GraphQL error
 type graphQLError struct {
-	Message string `json:"message"`
+	Message string        `json:"message"`
 	Path    []interface{} `json:"path,omitempty"`
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,157 @@
+// Copyright © 2024 Clearhaus
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// Config holds the configuration for the Humio client
+type Config struct {
+	Address          *url.URL
+	Token            string
+	CACertificatePEM string
+}
+
+// Client is the Humio API client
+type Client struct {
+	config     Config
+	httpClient *http.Client
+}
+
+// NewClient creates a new Humio client
+func NewClient(config Config) *Client {
+	transport := &http.Transport{}
+
+	if config.CACertificatePEM != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(config.CACertificatePEM))
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: caCertPool,
+		}
+	}
+
+	return &Client{
+		config: config,
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+}
+
+// graphQLRequest represents a GraphQL request
+type graphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// graphQLResponse represents a GraphQL response
+type graphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphQLError  `json:"errors,omitempty"`
+}
+
+// graphQLError represents a GraphQL error
+type graphQLError struct {
+	Message string `json:"message"`
+	Path    []interface{} `json:"path,omitempty"`
+}
+
+// Query executes a GraphQL query and unmarshals the result into the provided target
+func (c *Client) Query(ctx context.Context, query string, variables map[string]interface{}, target interface{}) error {
+	reqBody := graphQLRequest{
+		Query:     query,
+		Variables: variables,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	graphqlURL := c.config.Address.JoinPath("graphql")
+	req, err := http.NewRequestWithContext(ctx, "POST", graphqlURL.String(), bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.config.Token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	var gqlResp graphQLResponse
+	if err := json.Unmarshal(body, &gqlResp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return fmt.Errorf("GraphQL error: %s", gqlResp.Errors[0].Message)
+	}
+
+	if target != nil {
+		if err := json.Unmarshal(gqlResp.Data, target); err != nil {
+			return fmt.Errorf("failed to unmarshal data: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Alerts returns the Alerts API
+func (c *Client) Alerts() *Alerts {
+	return &Alerts{client: c}
+}
+
+// Actions returns the Actions API
+func (c *Client) Actions() *Actions {
+	return &Actions{client: c}
+}
+
+// Parsers returns the Parsers API
+func (c *Client) Parsers() *Parsers {
+	return &Parsers{client: c}
+}
+
+// Repositories returns the Repositories API
+func (c *Client) Repositories() *Repositories {
+	return &Repositories{client: c}
+}
+
+// IngestTokens returns the IngestTokens API
+func (c *Client) IngestTokens() *IngestTokens {
+	return &IngestTokens{client: c}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -105,7 +105,11 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]i
 	}
 
 	if len(gqlResp.Errors) > 0 {
-		return fmt.Errorf("GraphQL error: %s", gqlResp.Errors[0].Message)
+		messages := make([]string, len(gqlResp.Errors))
+		for i, e := range gqlResp.Errors {
+			messages[i] = e.Message
+		}
+		return fmt.Errorf("GraphQL errors: %v", messages)
 	}
 
 	if target != nil {

--- a/internal/api/ingest_tokens.go
+++ b/internal/api/ingest_tokens.go
@@ -80,10 +80,9 @@ mutation UnassignParser($RepositoryName: String!, $TokenName: String!) {
 
 const removeIngestTokenMutation = `
 mutation RemoveIngestToken($RepositoryName: String!, $Name: String!) {
-  removeIngestToken(input: {
-    repositoryName: $RepositoryName
-    name: $Name
-  })
+  removeIngestToken(repositoryName: $RepositoryName, name: $Name) {
+    __typename
+  }
 }
 `
 

--- a/internal/api/ingest_tokens.go
+++ b/internal/api/ingest_tokens.go
@@ -33,7 +33,7 @@ query ListIngestTokens($RepositoryName: String!) {
 
 const addIngestTokenMutation = `
 mutation AddIngestToken($RepositoryName: String!, $Name: String!, $Parser: String) {
-  addIngestToken(input: {
+  addIngestTokenV3(input: {
     repositoryName: $RepositoryName
     name: $Name
     parser: $Parser
@@ -102,13 +102,13 @@ type ingestTokenResponse struct {
 
 // addIngestTokenResponse represents the response from add ingest token mutation
 type addIngestTokenResponse struct {
-	AddIngestToken struct {
+	AddIngestTokenV3 struct {
 		Name   string `json:"name"`
 		Token  string `json:"token"`
 		Parser *struct {
 			Name string `json:"name"`
 		} `json:"parser"`
-	} `json:"addIngestToken"`
+	} `json:"addIngestTokenV3"`
 }
 
 // assignParserResponse represents the response from assign/unassign parser mutation
@@ -188,13 +188,13 @@ func (t *IngestTokens) Add(repository, name, parser string) (*IngestToken, error
 	}
 
 	assignedParser := ""
-	if resp.AddIngestToken.Parser != nil {
-		assignedParser = resp.AddIngestToken.Parser.Name
+	if resp.AddIngestTokenV3.Parser != nil {
+		assignedParser = resp.AddIngestTokenV3.Parser.Name
 	}
 
 	return &IngestToken{
-		Name:           resp.AddIngestToken.Name,
-		Token:          resp.AddIngestToken.Token,
+		Name:           resp.AddIngestTokenV3.Name,
+		Token:          resp.AddIngestTokenV3.Token,
 		AssignedParser: assignedParser,
 	}, nil
 }

--- a/internal/api/ingest_tokens.go
+++ b/internal/api/ingest_tokens.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (

--- a/internal/api/ingest_tokens.go
+++ b/internal/api/ingest_tokens.go
@@ -1,0 +1,272 @@
+// Copyright © 2024 Clearhaus
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+// IngestToken represents a Humio ingest token
+type IngestToken struct {
+	Name           string
+	Token          string
+	AssignedParser string
+}
+
+// IngestTokens provides operations for managing ingest tokens
+type IngestTokens struct {
+	client *Client
+}
+
+const listIngestTokensQuery = `
+query ListIngestTokens($RepositoryName: String!) {
+  repository(name: $RepositoryName) {
+    ingestTokens {
+      name
+      token
+      parser {
+        name
+      }
+    }
+  }
+}
+`
+
+const addIngestTokenMutation = `
+mutation AddIngestToken($RepositoryName: String!, $Name: String!, $Parser: String) {
+  addIngestToken(input: {
+    repositoryName: $RepositoryName
+    name: $Name
+    parser: $Parser
+  }) {
+    name
+    token
+    parser {
+      name
+    }
+  }
+}
+`
+
+const assignParserMutation = `
+mutation AssignParser($RepositoryName: String!, $TokenName: String!, $ParserName: String!) {
+  assignParserToIngestToken(input: {
+    repositoryName: $RepositoryName
+    tokenName: $TokenName
+    parserName: $ParserName
+  }) {
+    name
+    token
+    parser {
+      name
+    }
+  }
+}
+`
+
+const unassignParserMutation = `
+mutation UnassignParser($RepositoryName: String!, $TokenName: String!) {
+  unassignParserFromIngestToken(input: {
+    repositoryName: $RepositoryName
+    tokenName: $TokenName
+  }) {
+    name
+    token
+    parser {
+      name
+    }
+  }
+}
+`
+
+const removeIngestTokenMutation = `
+mutation RemoveIngestToken($RepositoryName: String!, $Name: String!) {
+  removeIngestToken(input: {
+    repositoryName: $RepositoryName
+    name: $Name
+  })
+}
+`
+
+// ingestTokenResponse represents the response from list ingest tokens query
+type ingestTokenResponse struct {
+	Repository struct {
+		IngestTokens []struct {
+			Name   string `json:"name"`
+			Token  string `json:"token"`
+			Parser *struct {
+				Name string `json:"name"`
+			} `json:"parser"`
+		} `json:"ingestTokens"`
+	} `json:"repository"`
+}
+
+// addIngestTokenResponse represents the response from add ingest token mutation
+type addIngestTokenResponse struct {
+	AddIngestToken struct {
+		Name   string `json:"name"`
+		Token  string `json:"token"`
+		Parser *struct {
+			Name string `json:"name"`
+		} `json:"parser"`
+	} `json:"addIngestToken"`
+}
+
+// assignParserResponse represents the response from assign/unassign parser mutation
+type assignParserResponse struct {
+	AssignParserToIngestToken *struct {
+		Name   string `json:"name"`
+		Token  string `json:"token"`
+		Parser *struct {
+			Name string `json:"name"`
+		} `json:"parser"`
+	} `json:"assignParserToIngestToken,omitempty"`
+	UnassignParserFromIngestToken *struct {
+		Name   string `json:"name"`
+		Token  string `json:"token"`
+		Parser *struct {
+			Name string `json:"name"`
+		} `json:"parser"`
+	} `json:"unassignParserFromIngestToken,omitempty"`
+}
+
+// List returns all ingest tokens for the given repository
+func (t *IngestTokens) List(repository string) ([]IngestToken, error) {
+	var resp ingestTokenResponse
+	err := t.client.Query(context.Background(), listIngestTokensQuery, map[string]interface{}{
+		"RepositoryName": repository,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := make([]IngestToken, len(resp.Repository.IngestTokens))
+	for i, token := range resp.Repository.IngestTokens {
+		assignedParser := ""
+		if token.Parser != nil {
+			assignedParser = token.Parser.Name
+		}
+		tokens[i] = IngestToken{
+			Name:           token.Name,
+			Token:          token.Token,
+			AssignedParser: assignedParser,
+		}
+	}
+
+	return tokens, nil
+}
+
+// Get returns an ingest token by name
+func (t *IngestTokens) Get(repository, name string) (*IngestToken, error) {
+	tokens, err := t.List(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, token := range tokens {
+		if token.Name == name {
+			return &token, nil
+		}
+	}
+
+	return nil, fmt.Errorf("ingest token not found: %s", name)
+}
+
+// Add creates a new ingest token
+func (t *IngestTokens) Add(repository, name, parser string) (*IngestToken, error) {
+	variables := map[string]interface{}{
+		"RepositoryName": repository,
+		"Name":           name,
+	}
+	if parser != "" {
+		variables["Parser"] = parser
+	}
+
+	var resp addIngestTokenResponse
+	err := t.client.Query(context.Background(), addIngestTokenMutation, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	assignedParser := ""
+	if resp.AddIngestToken.Parser != nil {
+		assignedParser = resp.AddIngestToken.Parser.Name
+	}
+
+	return &IngestToken{
+		Name:           resp.AddIngestToken.Name,
+		Token:          resp.AddIngestToken.Token,
+		AssignedParser: assignedParser,
+	}, nil
+}
+
+// Update updates an existing ingest token's parser assignment
+func (t *IngestTokens) Update(repository, name, parser string) (*IngestToken, error) {
+	var resp assignParserResponse
+	var err error
+
+	if parser == "" {
+		err = t.client.Query(context.Background(), unassignParserMutation, map[string]interface{}{
+			"RepositoryName": repository,
+			"TokenName":      name,
+		}, &resp)
+		if err != nil {
+			return nil, err
+		}
+		if resp.UnassignParserFromIngestToken != nil {
+			assignedParser := ""
+			if resp.UnassignParserFromIngestToken.Parser != nil {
+				assignedParser = resp.UnassignParserFromIngestToken.Parser.Name
+			}
+			return &IngestToken{
+				Name:           resp.UnassignParserFromIngestToken.Name,
+				Token:          resp.UnassignParserFromIngestToken.Token,
+				AssignedParser: assignedParser,
+			}, nil
+		}
+	} else {
+		err = t.client.Query(context.Background(), assignParserMutation, map[string]interface{}{
+			"RepositoryName": repository,
+			"TokenName":      name,
+			"ParserName":     parser,
+		}, &resp)
+		if err != nil {
+			return nil, err
+		}
+		if resp.AssignParserToIngestToken != nil {
+			assignedParser := ""
+			if resp.AssignParserToIngestToken.Parser != nil {
+				assignedParser = resp.AssignParserToIngestToken.Parser.Name
+			}
+			return &IngestToken{
+				Name:           resp.AssignParserToIngestToken.Name,
+				Token:          resp.AssignParserToIngestToken.Token,
+				AssignedParser: assignedParser,
+			}, nil
+		}
+	}
+
+	// If we get here, fetch the token to return
+	return t.Get(repository, name)
+}
+
+// Remove deletes an ingest token
+func (t *IngestTokens) Remove(repository, name string) error {
+	return t.client.Query(context.Background(), removeIngestTokenMutation, map[string]interface{}{
+		"RepositoryName": repository,
+		"Name":           name,
+	}, nil)
+}

--- a/internal/api/parsers.go
+++ b/internal/api/parsers.go
@@ -133,10 +133,10 @@ type listParsersResponse struct {
 type getParserResponse struct {
 	Repository struct {
 		Parser *struct {
-			ID         string `json:"id"`
-			Name       string `json:"name"`
-			Script     string `json:"script"`
-			TestCases  []struct {
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			Script    string `json:"script"`
+			TestCases []struct {
 				Event struct {
 					RawString string `json:"rawString"`
 				} `json:"event"`

--- a/internal/api/parsers.go
+++ b/internal/api/parsers.go
@@ -1,0 +1,234 @@
+// Copyright © 2024 Clearhaus
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+// ParserTestEvent represents a test event for a parser
+type ParserTestEvent struct {
+	RawString string
+}
+
+// ParserTestCase represents a test case for a parser
+type ParserTestCase struct {
+	Event ParserTestEvent
+}
+
+// Parser represents a Humio parser
+type Parser struct {
+	ID          string
+	Name        string
+	Script      string
+	FieldsToTag []string
+	TestCases   []ParserTestCase
+}
+
+// Parsers provides operations for managing parsers
+type Parsers struct {
+	client *Client
+}
+
+const listParsersQuery = `
+query ListParsers($RepositoryName: String!) {
+  repository(name: $RepositoryName) {
+    parsers {
+      id
+      name
+      isBuiltIn
+    }
+  }
+}
+`
+
+const getParserQuery = `
+query GetParser($RepositoryName: String!, $ParserName: String!) {
+  repository(name: $RepositoryName) {
+    parser(name: $ParserName) {
+      id
+      name
+      sourceCode
+      testData
+      tagFields
+    }
+  }
+}
+`
+
+const createParserMutation = `
+mutation CreateParser(
+  $RepositoryName: String!
+  $Name: String!
+  $SourceCode: String!
+  $TestData: [String!]
+  $TagFields: [String!]
+  $Force: Boolean
+) {
+  createParser(input: {
+    repositoryName: $RepositoryName
+    name: $Name
+    sourceCode: $SourceCode
+    testData: $TestData
+    tagFields: $TagFields
+    force: $Force
+  }) {
+    id
+    name
+  }
+}
+`
+
+const deleteParserMutation = `
+mutation DeleteParser($RepositoryName: String!, $ParserID: String!) {
+  deleteParser(input: {
+    repositoryName: $RepositoryName
+    id: $ParserID
+  })
+}
+`
+
+// listParsersResponse represents the response from list parsers query
+type listParsersResponse struct {
+	Repository struct {
+		Parsers []struct {
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			IsBuiltIn bool   `json:"isBuiltIn"`
+		} `json:"parsers"`
+	} `json:"repository"`
+}
+
+// getParserResponse represents the response from get parser query
+type getParserResponse struct {
+	Repository struct {
+		Parser *struct {
+			ID         string   `json:"id"`
+			Name       string   `json:"name"`
+			SourceCode string   `json:"sourceCode"`
+			TestData   []string `json:"testData"`
+			TagFields  []string `json:"tagFields"`
+		} `json:"parser"`
+	} `json:"repository"`
+}
+
+// createParserResponse represents the response from create parser mutation
+type createParserResponse struct {
+	CreateParser struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"createParser"`
+}
+
+// List returns all parsers for the given repository
+func (p *Parsers) List(repository string) ([]Parser, error) {
+	var resp listParsersResponse
+	err := p.client.Query(context.Background(), listParsersQuery, map[string]interface{}{
+		"RepositoryName": repository,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	parsers := make([]Parser, 0, len(resp.Repository.Parsers))
+	for _, parser := range resp.Repository.Parsers {
+		if !parser.IsBuiltIn {
+			parsers = append(parsers, Parser{
+				ID:   parser.ID,
+				Name: parser.Name,
+			})
+		}
+	}
+
+	return parsers, nil
+}
+
+// Get returns a parser by name
+func (p *Parsers) Get(repository, name string) (*Parser, error) {
+	var resp getParserResponse
+	err := p.client.Query(context.Background(), getParserQuery, map[string]interface{}{
+		"RepositoryName": repository,
+		"ParserName":     name,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Repository.Parser == nil {
+		return nil, fmt.Errorf("parser not found: %s", name)
+	}
+
+	rawParser := resp.Repository.Parser
+	testCases := make([]ParserTestCase, len(rawParser.TestData))
+	for i, testData := range rawParser.TestData {
+		testCases[i] = ParserTestCase{
+			Event: ParserTestEvent{
+				RawString: testData,
+			},
+		}
+	}
+
+	return &Parser{
+		ID:          rawParser.ID,
+		Name:        rawParser.Name,
+		Script:      rawParser.SourceCode,
+		FieldsToTag: rawParser.TagFields,
+		TestCases:   testCases,
+	}, nil
+}
+
+// Add creates a new parser or updates an existing one
+func (p *Parsers) Add(repository string, parser *Parser, force bool) (*Parser, error) {
+	testData := make([]string, len(parser.TestCases))
+	for i, tc := range parser.TestCases {
+		testData[i] = tc.Event.RawString
+	}
+
+	variables := map[string]interface{}{
+		"RepositoryName": repository,
+		"Name":           parser.Name,
+		"SourceCode":     parser.Script,
+		"TagFields":      parser.FieldsToTag,
+		"Force":          force,
+	}
+
+	if len(testData) > 0 {
+		variables["TestData"] = testData
+	}
+
+	var resp createParserResponse
+	err := p.client.Query(context.Background(), createParserMutation, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	parser.ID = resp.CreateParser.ID
+	return parser, nil
+}
+
+// Delete deletes a parser by name
+func (p *Parsers) Delete(repository, name string) error {
+	// First get the parser to find its ID
+	parser, err := p.Get(repository, name)
+	if err != nil {
+		return err
+	}
+
+	return p.client.Query(context.Background(), deleteParserMutation, map[string]interface{}{
+		"RepositoryName": repository,
+		"ParserID":       parser.ID,
+	}, nil)
+}

--- a/internal/api/parsers.go
+++ b/internal/api/parsers.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (

--- a/internal/api/repositories.go
+++ b/internal/api/repositories.go
@@ -31,21 +31,15 @@ query GetRepository($RepositoryName: String!) {
 const createRepositoryMutation = `
 mutation CreateRepository($Name: String!) {
   createRepository(name: $Name) {
-    id
-    name
+    __typename
   }
 }
 `
 
 const updateDescriptionMutation = `
 mutation UpdateDescription($RepositoryName: String!, $Description: String!) {
-  updateDescriptionForSearchDomain(input: {
-    name: $RepositoryName
-    description: $Description
-  }) {
-    id
-    name
-    description
+  updateDescriptionForSearchDomain(name: $RepositoryName, newDescription: $Description) {
+    __typename
   }
 }
 `
@@ -97,14 +91,6 @@ type getRepositoryResponse struct {
 	} `json:"repository"`
 }
 
-// createRepositoryResponse represents the response from create repository mutation
-type createRepositoryResponse struct {
-	CreateRepository struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"createRepository"`
-}
-
 // List returns all repositories
 func (r *Repositories) List() ([]Repository, error) {
 	var resp listRepositoriesResponse
@@ -148,10 +134,9 @@ func (r *Repositories) Get(name string) (Repository, error) {
 
 // Create creates a new repository
 func (r *Repositories) Create(name string) error {
-	var resp createRepositoryResponse
 	return r.client.Query(context.Background(), createRepositoryMutation, map[string]interface{}{
 		"Name": name,
-	}, &resp)
+	}, nil)
 }
 
 // UpdateDescription updates the description of a repository

--- a/internal/api/repositories.go
+++ b/internal/api/repositories.go
@@ -45,22 +45,27 @@ mutation UpdateDescription($RepositoryName: String!, $Description: String!) {
 `
 
 const updateTimeBasedRetentionMutation = `
-mutation UpdateTimeBasedRetention($RepositoryName: String!, $RetentionDays: Float, $AllowDataDeletion: Boolean!) {
-  updateRetentionForSearchDomain(input: {
+mutation UpdateTimeBasedRetention($RepositoryName: String!, $RetentionDays: Float) {
+  updateRetention(
     repositoryName: $RepositoryName
     timeBasedRetention: $RetentionDays
-    allowDataDeletion: $AllowDataDeletion
-  }) {
-    id
-    name
-    timeBasedRetention
+  ) {
+    repository {
+      id
+      name
+      ... on Repository {
+        timeBasedRetention
+      }
+    }
   }
 }
 `
 
 const deleteRepositoryMutation = `
-mutation DeleteRepository($RepositoryName: String!, $Reason: String!, $AllowDataDeletion: Boolean!) {
-  deleteSearchDomain(name: $RepositoryName, deleteMessage: $Reason, allowDataDeletion: $AllowDataDeletion)
+mutation DeleteRepository($RepositoryName: String!, $Reason: String) {
+  deleteSearchDomain(name: $RepositoryName, deleteMessage: $Reason) {
+    result
+  }
 }
 `
 
@@ -148,10 +153,9 @@ func (r *Repositories) UpdateDescription(name, description string) error {
 }
 
 // UpdateTimeBasedRetention updates the time-based retention for a repository
-func (r *Repositories) UpdateTimeBasedRetention(name string, retentionDays float64, allowDataDeletion bool) error {
+func (r *Repositories) UpdateTimeBasedRetention(name string, retentionDays float64) error {
 	variables := map[string]interface{}{
-		"RepositoryName":    name,
-		"AllowDataDeletion": allowDataDeletion,
+		"RepositoryName": name,
 	}
 
 	// Only set retention if it's > 0, otherwise null means unlimited
@@ -163,10 +167,9 @@ func (r *Repositories) UpdateTimeBasedRetention(name string, retentionDays float
 }
 
 // Delete deletes a repository
-func (r *Repositories) Delete(name, reason string, allowDataDeletion bool) error {
+func (r *Repositories) Delete(name, reason string) error {
 	return r.client.Query(context.Background(), deleteRepositoryMutation, map[string]interface{}{
-		"RepositoryName":    name,
-		"Reason":            reason,
-		"AllowDataDeletion": allowDataDeletion,
+		"RepositoryName": name,
+		"Reason":         reason,
 	}, nil)
 }

--- a/internal/api/repositories.go
+++ b/internal/api/repositories.go
@@ -1,17 +1,3 @@
-// Copyright © 2024 Clearhaus
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package api
 
 import (

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -57,4 +57,3 @@ func (u *Users) GetCurrent() (*User, error) {
 		IsRoot:   resp.CurrentUser.IsRoot,
 	}, nil
 }
-

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+)
+
+// User represents a Humio user
+type User struct {
+	ID       string
+	Username string
+	FullName string
+	Email    string
+	IsRoot   bool
+}
+
+// Users provides operations for managing users
+type Users struct {
+	client *Client
+}
+
+const currentUserQuery = `
+query CurrentUser {
+  currentUser {
+    id
+    username
+    fullName
+    email
+    isRoot
+  }
+}
+`
+
+// currentUserResponse represents the response from current user query
+type currentUserResponse struct {
+	CurrentUser struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		FullName string `json:"fullName"`
+		Email    string `json:"email"`
+		IsRoot   bool   `json:"isRoot"`
+	} `json:"currentUser"`
+}
+
+// GetCurrent returns the current authenticated user
+func (u *Users) GetCurrent() (*User, error) {
+	var resp currentUserResponse
+	err := u.client.Query(context.Background(), currentUserQuery, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &User{
+		ID:       resp.CurrentUser.ID,
+		Username: resp.CurrentUser.Username,
+		FullName: resp.CurrentUser.FullName,
+		Email:    resp.CurrentUser.Email,
+		IsRoot:   resp.CurrentUser.IsRoot,
+	}, nil
+}
+

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/humio/terraform-provider-humio/humio"
+	"github.com/clearhaus/terraform-provider-humio/humio"
 )
 
 var (


### PR DESCRIPTION
This pull request refactors the Humio Terraform provider to remove its dependency on the external `github.com/humio/cli` package by introducing an internal API client implementation. The main changes involve replacing all usages of the external Humio API client with the new in-repo client, updating imports, and adding new internal API code for alert management.

Key changes include:

**Internal API Client Implementation**

* Added a new internal API client in `internal/api/client.go` that provides GraphQL request handling, authentication, and resource-specific API accessors (alerts, actions, parsers, repositories, ingest tokens). This eliminates the need for the external `humio/cli` dependency.

**Alert Management API**

* Introduced a new internal alert management implementation in `internal/api/alerts.go`, including types and methods for listing, creating, updating, and deleting alerts via GraphQL.

**Provider Code Refactoring**

* Updated all provider and resource files to import the new internal API client (`github.com/humio/terraform-provider-humio/internal/api`) instead of the external `humio/cli/api` package. [[1]](diffhunk://#diff-dfe0c7aaa1a8522af8724878dbcd239162e908eb38c35959522e4cdd68bad8b3L28-R28) [[2]](diffhunk://#diff-11dba0325dd7200aab5f720232b2668edb286ddfbfc2a63311f966e2061febc7L29-R29) [[3]](diffhunk://#diff-24d1e2c061b92454b435481dbcd5ba7f21ee9d9d7766d5e80a5125631fa86fbbL25-R25) [[4]](diffhunk://#diff-27032e15a3a1b7da4dc8713186addf9e801be5ab3980c20f8b898966985c7be2L25-R25) [[5]](diffhunk://#diff-6d2f2bc4671da454943e62cadd5009c59adafe88b359a7931f76718b28944ca1L25-R25) [[6]](diffhunk://#diff-becf4e7cba4e2add16208b69e2699d13d8f1fc1dca58dfeda30ff2086487bd59L24-R24) [[7]](diffhunk://#diff-df025c33d876a37d5d1b20e2389dea018fee0d1745f8df4fd545660cab41c30aL24-R24) [[8]](diffhunk://#diff-a348f2a27011ebca0a84fef66760c5fb44a0fcf6197cf1dfdf94bf2edb9f2028L25-R25) [[9]](diffhunk://#diff-e53b5b7c35533da617d72b9fa2654d78f16f28565314d4276bf67d5736b94c00L25-R25) [[10]](diffhunk://#diff-33afbea59f88cc8e6ccd51e7da55734a1f147c1846580260a1fd401fde8111daL10-R10) [[11]](diffhunk://#diff-1580e59864305722a5877d63fd9c9e35d8032c6cfd2a4e2a6e66d3608b5f6d03L23-R23)

**Dependency Cleanup**

* Removed the `github.com/humio/cli` dependency and related indirect dependencies from `go.mod`.

**Test Data Update**

* Updated test data in `resource_repository_test.go` to remove fields that are no longer present in the new internal API.