### PR TITLE
Fix action resource deletion

### DIFF
--- a/humio/resource_action.go
+++ b/humio/resource_action.go
@@ -436,7 +436,7 @@ func resourceActionDelete(_ context.Context, d *schema.ResourceData, client inte
 
 	err = client.(*humio.Client).Actions().Delete(
 		d.Get("repository").(string),
-		action.Name,
+		action.ID,
 	)
 	if err != nil {
 		return diag.Errorf("could not delete action: %s", err)


### PR DESCRIPTION
Changed `action.Name` to `action.ID` which correctly passes the action ID from the Terraform state (`action_id` attribute) to the delete mutation.